### PR TITLE
Introduce CC and hls_master_url

### DIFF
--- a/src/media/stream.rs
+++ b/src/media/stream.rs
@@ -58,6 +58,7 @@ pub struct VideoStream {
     pub audio_locale: Locale,
     /// All subtitles.
     pub subtitles: HashMap<Locale, StreamSubtitle>,
+    pub closed_captions: HashMap<Locale, StreamSubtitle>,
 
     /// All stream variants.
     /// One stream has multiple variants how it can be delivered. At the time of writing,
@@ -74,8 +75,6 @@ pub struct VideoStream {
 
     #[cfg(feature = "__test_strict")]
     captions: crate::StrictValue,
-    #[cfg(feature = "__test_strict")]
-    closed_captions: crate::StrictValue,
     #[cfg(feature = "__test_strict")]
     bifs: crate::StrictValue,
     #[cfg(feature = "__test_strict")]

--- a/src/media/streaming.rs
+++ b/src/media/streaming.rs
@@ -195,10 +195,14 @@ pub struct VariantData {
     pub fps: f64,
     pub codecs: String,
 
-    pub url: VariantDataUrl,
+    url: VariantDataUrl,
 }
 
 impl VariantData {
+    pub(crate) async fn get_url() -> Result<VariantDataUrl>{
+    Ok(self.url)
+    }
+    
     #[cfg(feature = "hls-stream")]
     pub(crate) async fn from_hls_master(
         executor: Arc<Executor>,

--- a/src/media/streaming.rs
+++ b/src/media/streaming.rs
@@ -199,7 +199,7 @@ pub struct VariantData {
 }
 
 impl VariantData {
-    pub(crate) async fn get_url() -> Result<VariantDataUrl>{
+    pub(crate) async fn get_url(&self) -> Result<VariantDataUrl>{
     Ok(self.url)
     }
     

--- a/src/media/streaming.rs
+++ b/src/media/streaming.rs
@@ -195,7 +195,7 @@ pub struct VariantData {
     pub fps: f64,
     pub codecs: String,
 
-    url: VariantDataUrl,
+    pub url: VariantDataUrl,
 }
 
 impl VariantData {

--- a/src/media/streaming.rs
+++ b/src/media/streaming.rs
@@ -422,7 +422,7 @@ impl VariantData {
     // Get the m3u8 url if you want to use ffmpeg to handle all the download process
     // It can be faster to download yourself segment by segment
     #[cfg(feature = "hls-stream")]
-    pub fn hls_get_master_url(&self) -> Result<String> {
+    pub fn hls_master_url(&self) -> Result<String> {
         #[allow(irrefutable_let_patterns)]
         let VariantDataUrl::Hls { url } = &self.url else {
             return Err(CrunchyrollError::Internal("variant url should be hls".into()))

--- a/src/media/streaming.rs
+++ b/src/media/streaming.rs
@@ -199,8 +199,8 @@ pub struct VariantData {
 }
 
 impl VariantData {
-    pub(crate) async fn get_url(&self) -> Result<VariantDataUrl>{
-    Ok(self.url)
+    pub fn get_url(&self) -> VariantDataUrl{
+        self.url
     }
     
     #[cfg(feature = "hls-stream")]

--- a/src/media/streaming.rs
+++ b/src/media/streaming.rs
@@ -419,6 +419,17 @@ impl VariantData {
         Ok(segments)
     }
 
+    // Get the m3u8 url if you want to use ffmpeg to handle all the download process
+    // It can be faster to download yourself segment by segment
+    #[cfg(feature = "hls-stream")]
+    pub fn hls_get_master_url(&self) -> Result<String> {
+        #[allow(irrefutable_let_patterns)]
+        let VariantDataUrl::Hls { url } = &self.url else {
+            return Err(CrunchyrollError::Internal("variant url should be hls".into()))
+        };
+        Ok(url.to_string())
+    }
+
     #[cfg(feature = "dash-stream")]
     async fn dash_segments(&self) -> Result<Vec<VariantSegment>> {
         #[allow(irrefutable_let_patterns)]

--- a/src/media/streaming.rs
+++ b/src/media/streaming.rs
@@ -460,10 +460,6 @@ impl VariantData {
 
         Ok(segments)
     }
-
-    pub fn get_url(&self) -> VariantDataUrl {
-        self.url.clone()
-    }
 }
 
 /// A single segment, representing a part of a video stream.

--- a/src/media/streaming.rs
+++ b/src/media/streaming.rs
@@ -199,7 +199,6 @@ pub struct VariantData {
 }
 
 impl VariantData {
-    
     #[cfg(feature = "hls-stream")]
     pub(crate) async fn from_hls_master(
         executor: Arc<Executor>,
@@ -461,7 +460,7 @@ impl VariantData {
 
         Ok(segments)
     }
-    
+
     pub fn get_url(&self) -> VariantDataUrl {
         self.url
     }

--- a/src/media/streaming.rs
+++ b/src/media/streaming.rs
@@ -199,9 +199,6 @@ pub struct VariantData {
 }
 
 impl VariantData {
-    pub fn get_url(&self) -> VariantDataUrl{
-        self.url
-    }
     
     #[cfg(feature = "hls-stream")]
     pub(crate) async fn from_hls_master(
@@ -464,6 +461,11 @@ impl VariantData {
 
         Ok(segments)
     }
+    
+    pub fn get_url(&self) -> VariantDataUrl {
+        self.url
+    }
+
 }
 
 /// A single segment, representing a part of a video stream.

--- a/src/media/streaming.rs
+++ b/src/media/streaming.rs
@@ -464,7 +464,6 @@ impl VariantData {
     pub fn get_url(&self) -> VariantDataUrl {
         self.url
     }
-
 }
 
 /// A single segment, representing a part of a video stream.

--- a/src/media/streaming.rs
+++ b/src/media/streaming.rs
@@ -462,7 +462,7 @@ impl VariantData {
     }
 
     pub fn get_url(&self) -> VariantDataUrl {
-        self.url
+        self.url.clone()
     }
 }
 


### PR DESCRIPTION
 - introduces the ability to access CCs if they exist
 - adds `hls_master_url` in order to allow access to the m3u8 file of a stream. This can be used with ffmpeg to allow it to handle everything by itself.