### PR TITLE
Update watch_history.

### DIFF
--- a/src/list/watch_history.rs
+++ b/src/list/watch_history.rs
@@ -1,8 +1,4 @@
-use std::sync::Arc;
-
-use crate::{
-    crunchyroll::Executor, options, Crunchyroll, EmptyJsonProxy, MediaCollection, Request, Result,
-};
+use crate::{options, Crunchyroll, EmptyJsonProxy, MediaCollection, Request, Result};
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
 
@@ -10,6 +6,7 @@ use serde::Deserialize;
 #[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
+#[request(executor(panel))]
 pub struct WatchHistoryEntry {
     pub id: String,
     pub parent_id: String,
@@ -24,7 +21,8 @@ pub struct WatchHistoryEntry {
 }
 
 #[allow(dead_code)]
-#[derive(Clone, Debug, Deserialize, smart_default::SmartDefault)]
+#[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
+#[request(executor(items))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 struct BulkWatchHistoryResult {
@@ -35,21 +33,6 @@ struct BulkWatchHistoryResult {
     #[default(crate::StrictValue::default())]
     // field does not appear when `items` is `[]` (empty)
     next_page: crate::StrictValue,
-}
-impl Request for BulkWatchHistoryResult {
-    fn __set_executor(&mut self, executor: Arc<Executor>) {
-        for item in self.items.iter_mut() {
-            let executor = executor.clone();
-            let panel = &mut item.panel;
-            match panel {
-                MediaCollection::Series(series) => series.executor = executor,
-                MediaCollection::Season(season) => season.executor = executor,
-                MediaCollection::Episode(episode) => episode.executor = executor,
-                MediaCollection::MovieListing(movie_listing) => movie_listing.executor = executor,
-                MediaCollection::Movie(movie) => movie.executor = executor,
-            }
-        }
-    }
 }
 
 options! {


### PR DESCRIPTION
Updated fully_watched so that the value can be properly parsed from JSON response. Added __set_executor for BulkWatchHistoryResult so that it is properly propagated to individual panels.