### PR TITLE
Add experimental stabilizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default = ["hls-stream", "parse"]
 hls-stream = ["aes", "cbc", "m3u8-rs"]
 dash-stream = ["dash-mpd"]
 # Add functionality to parse Crunchyroll urls.
-parse = ["regex"]
+parse = ["lazy_static", "regex"]
 
 # Internal! Do not use it outside of testing
 __test_strict = []
@@ -41,6 +41,7 @@ crunchyroll-rs-internal = { version = "0.2", path = "internal" }
 aes = { version = "0.8", optional = true }
 cbc = { version = "0.1", optional = true }
 dash-mpd = { version = "0.6", default-features = false, optional = true }
+lazy_static = { version = "1.4", optional = true }
 m3u8-rs = { version = "5.0", optional = true }
 regex = { version = "1.7", default-features = false, features = ["std"], optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["crunchyroll", "anime", "downloader"]
 categories = ["api-bindings"]
 
 [features]
-default = ["hls-stream", "parse"]
+default = ["hls-stream", "parse", "experimental-stabilizations"]
 
 # Add functionality to stream episodes / movies so you can process the unencrypted streaming data further, e.g. write it
 # to a file and then play it.
@@ -19,11 +19,14 @@ hls-stream = ["aes", "cbc", "m3u8-rs"]
 dash-stream = ["dash-mpd"]
 # Add functionality to parse Crunchyroll urls.
 parse = ["lazy_static", "regex"]
+# Add various stabilizations as Crunchyroll delivers wrong api results in some cases.
+experimental-stabilizations = ["lazy_static", "regex"]
 
 # Internal! Do not use it outside of testing
 __test_strict = []
 
 [dependencies]
+async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 http = "0.2"
 reqwest = { version = "0.11", features = ["cookies", "json", "rustls-tls"], default-features = false }

--- a/internal/src/lib.rs
+++ b/internal/src/lib.rs
@@ -58,8 +58,9 @@ pub fn derive_request(input: TokenStream) -> TokenStream {
     };
 
     let expanded = quote! {
+        #[async_trait::async_trait(?Send)]
         impl #impl_generics crate::Request for #ident #ty_generics # where_clause {
-            fn __set_executor(&mut self, executor: std::sync::Arc<crate::Executor>) {
+            async fn __set_executor(&mut self, executor: std::sync::Arc<crate::Executor>) {
                 #(#impl_executor)*
             }
         }
@@ -111,7 +112,7 @@ fn derive_request_check(set_path: TokenStream2, path: &Path) -> TokenStream2 {
         }
     } else {
         quote! {
-            #set_path.__set_executor(executor.clone());
+            #set_path.__set_executor(executor.clone()).await;
         }
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -17,10 +17,11 @@ pub struct BulkResult<T: Default + DeserializeOwned + Request> {
     pub total: u32,
 }
 
+#[async_trait::async_trait(?Send)]
 impl<T: Default + DeserializeOwned + Request> Request for BulkResult<T> {
-    fn __set_executor(&mut self, executor: Arc<Executor>) {
+    async fn __set_executor(&mut self, executor: Arc<Executor>) {
         for item in self.items.iter_mut() {
-            item.__set_executor(executor.clone())
+            item.__set_executor(executor.clone()).await;
         }
     }
 }
@@ -35,10 +36,11 @@ pub struct CrappyBulkResult<T: Default + DeserializeOwned + Request> {
     pub items: Vec<T>,
 }
 
+#[async_trait::async_trait(?Send)]
 impl<T: Default + DeserializeOwned + Request> Request for CrappyBulkResult<T> {
-    fn __set_executor(&mut self, executor: Arc<Executor>) {
+    async fn __set_executor(&mut self, executor: Arc<Executor>) {
         for item in self.items.iter_mut() {
-            item.__set_executor(executor.clone())
+            item.__set_executor(executor.clone()).await;
         }
     }
 }
@@ -58,9 +60,10 @@ pub struct Image {
 /// Helper trait for [`Crunchyroll::request`] generic returns.
 /// Must be implemented for every struct which is used as generic parameter for [`Crunchyroll::request`].
 #[doc(hidden)]
+#[async_trait::async_trait(?Send)]
 pub trait Request {
     /// Set a usable [`Executor`] instance to the struct if required
-    fn __set_executor(&mut self, _: Arc<Executor>) {}
+    async fn __set_executor(&mut self, _: Arc<Executor>) {}
 }
 
 /// Implement [`Request`] for cases where only the request must be done without needing an

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,11 @@
 //! }
 //! ```
 //!
+//! # Bugs
+//! Crunchyroll is awful in keep their api clean. Thus, some things are broken, will break for no
+//! reason or aren't well implemented (if at all). The methods added with the
+//! `experimental-stabilizations` feature (`CrunchyrollBuilder::stabilization_*`)
+//!
 //! # Implementation
 //! To ensure at least all existing parts of the library are working as expected, a special feature
 //! only for testing is implemented. When running tests with the `__test_strict` feature, it ensures

--- a/src/media/media.rs
+++ b/src/media/media.rs
@@ -410,11 +410,11 @@ impl Default for MediaCollection {
 impl Request for MediaCollection {
     async fn __set_executor(&mut self, executor: Arc<Executor>) {
         match self {
-            MediaCollection::Series(series) => series.executor = executor,
-            MediaCollection::Season(season) => season.executor = executor,
-            MediaCollection::Episode(episode) => episode.executor = executor,
-            MediaCollection::MovieListing(movie_listing) => movie_listing.executor = executor,
-            MediaCollection::Movie(movie) => movie.executor = executor,
+            MediaCollection::Series(series) => series.__set_executor(executor).await,
+            MediaCollection::Season(season) => season.__set_executor(executor).await,
+            MediaCollection::Episode(episode) => episode.__set_executor(executor).await,
+            MediaCollection::MovieListing(movie_listing) => movie_listing.__set_executor(executor).await,
+            MediaCollection::Movie(movie) => movie.__set_executor(executor).await,
         }
     }
 }

--- a/src/media/media.rs
+++ b/src/media/media.rs
@@ -17,7 +17,7 @@ pub trait Video: Default + DeserializeOwned + Request {
 }
 
 #[cfg(feature = "experimental-stabilizations")]
-fn parse_locale_from_series_title<S: AsRef<str>>(title: S) -> Locale {
+pub(crate) fn parse_locale_from_series_title<S: AsRef<str>>(title: S) -> Locale {
     lazy_static::lazy_static! {
         static ref SERIES_LOCALE_REGEX: regex::Regex = regex::Regex::new(r".*\((?P<locale>\S+)(\sDub)?\)$").unwrap();
     }
@@ -413,7 +413,9 @@ impl Request for MediaCollection {
             MediaCollection::Series(series) => series.__set_executor(executor).await,
             MediaCollection::Season(season) => season.__set_executor(executor).await,
             MediaCollection::Episode(episode) => episode.__set_executor(executor).await,
-            MediaCollection::MovieListing(movie_listing) => movie_listing.__set_executor(executor).await,
+            MediaCollection::MovieListing(movie_listing) => {
+                movie_listing.__set_executor(executor).await
+            }
             MediaCollection::Movie(movie) => movie.__set_executor(executor).await,
         }
     }

--- a/src/media/old_media.rs
+++ b/src/media/old_media.rs
@@ -15,7 +15,7 @@ pub(crate) struct OldMediaImages {
 }
 
 #[allow(dead_code)]
-#[derive(Debug, Deserialize, smart_default::SmartDefault, Request)]
+#[derive(Debug, Deserialize, smart_default::SmartDefault)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub(crate) struct OldEpisode {
@@ -123,6 +123,16 @@ pub(crate) struct OldEpisode {
     media_type: crate::StrictValue,
 }
 
+#[async_trait::async_trait(?Send)]
+impl Request for OldEpisode {
+    async fn __set_executor(&mut self, executor: Arc<Executor>) {
+        if executor.fixes.locale_name_parsing {
+            self.audio_locale = crate::media::parse_locale_from_series_title(&self.season_title)
+        }
+        self.executor = executor
+    }
+}
+
 #[allow(clippy::from_over_into)]
 impl Into<Media<Episode>> for OldEpisode {
     fn into(self) -> Media<Episode> {
@@ -204,7 +214,7 @@ impl Into<Media<Episode>> for OldEpisode {
 }
 
 #[allow(dead_code)]
-#[derive(Debug, Default, Deserialize, Request)]
+#[derive(Debug, Default, Deserialize)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub(crate) struct OldSeason {
@@ -254,6 +264,18 @@ pub(crate) struct OldSeason {
     versions: crate::StrictValue,
     #[cfg(feature = "__test_strict")]
     identifier: crate::StrictValue,
+}
+
+#[async_trait::async_trait(?Send)]
+impl Request for OldSeason {
+    async fn __set_executor(&mut self, executor: Arc<Executor>) {
+        if executor.fixes.locale_name_parsing {
+            let locale = crate::media::parse_locale_from_series_title(&self.title);
+            self.audio_locale = locale.clone();
+            self.audio_locales = vec![locale];
+        }
+        self.executor = executor
+    }
 }
 
 #[allow(clippy::from_over_into)]


### PR DESCRIPTION
Initial branch to approach weird Crunchyroll Api fuckups which requires some logic in the implementation that might break other things and cannot be considered 100% safe.

The `experimental-stabilizations` feature (enabled by default) grants access to `CrunchyrollBuilder::stabilization_*` functions. These functions can enable / disable different optimizations. All stabilizations are deactivated by default. The currently only available function is `stabilization_locale` to fix #3 -> Crunchyroll does not mark japanese audio as japanese anymore (it's marked as english instead). More may come in the future, depending how Crunchyroll breaks their api ¯\\_(ツ)_/¯.