### PR TITLE
Add pagination

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ __test_strict = []
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 http = "0.2"
+futures-util = { version = "0.3", features = ["std"], default-features = false }
 reqwest = { version = "0.11", features = ["cookies", "json", "rustls-tls"], default-features = false }
 rustls = { version = "0.20", features = ["dangerous_configuration"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/browse-genre.rs
+++ b/examples/browse-genre.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use crunchyroll_rs::categories::Category;
 use crunchyroll_rs::search::BrowseOptions;
 use crunchyroll_rs::{Crunchyroll, MediaCollection};
+use futures_util::StreamExt;
 use std::env;
 
 #[tokio::main]
@@ -18,10 +19,9 @@ async fn main() -> Result<()> {
         .is_dubbed(true)
         // only results which have action as a category / genre
         .categories(vec![Category::Action]);
-    let result = crunchyroll.browse(options).await?;
 
-    for item in result.data {
-        match item {
+    while let Some(item) = crunchyroll.browse(options.clone()).next().await {
+        match item? {
             MediaCollection::Series(series) => println!("Browse returned series {}", series.title),
             // is never season
             MediaCollection::Season(_) => (),

--- a/internal/src/lib.rs
+++ b/internal/src/lib.rs
@@ -58,7 +58,7 @@ pub fn derive_request(input: TokenStream) -> TokenStream {
     };
 
     let expanded = quote! {
-        #[async_trait::async_trait(?Send)]
+        #[async_trait::async_trait]
         impl #impl_generics crate::Request for #ident #ty_generics # where_clause {
             async fn __set_executor(&mut self, executor: std::sync::Arc<crate::Executor>) {
                 #(#impl_executor)*

--- a/src/account.rs
+++ b/src/account.rs
@@ -251,7 +251,6 @@ fn mature_content_flag_manga<'de, D: serde::Deserializer<'de>>(
 }
 
 mod wallpaper {
-    use crate::common::CrappyBulkResult;
     use crate::{Crunchyroll, Request, Result};
     use serde::Deserialize;
 
@@ -261,6 +260,14 @@ mod wallpaper {
     #[cfg_attr(not(feature = "__test_strict"), serde(default))]
     pub struct Wallpaper {
         pub name: String,
+    }
+
+    #[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
+    #[request(executor(items))]
+    #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
+    #[cfg_attr(not(feature = "__test_strict"), serde(default))]
+    struct WallpaperResult {
+        items: Vec<Wallpaper>,
     }
 
     impl From<String> for Wallpaper {
@@ -276,7 +283,7 @@ mod wallpaper {
             Ok(crunchyroll
                 .executor
                 .get(endpoint)
-                .request::<CrappyBulkResult<Wallpaper>>()
+                .request::<WallpaperResult>()
                 .await?
                 .items)
         }

--- a/src/common.rs
+++ b/src/common.rs
@@ -195,8 +195,8 @@ pub struct Image {
 /// Helper trait for [`Crunchyroll::request`] generic returns.
 /// Must be implemented for every struct which is used as generic parameter for [`Crunchyroll::request`].
 #[doc(hidden)]
-#[async_trait::async_trait(?Send)]
-pub trait Request {
+#[async_trait::async_trait]
+pub trait Request: Send {
     /// Set a usable [`Executor`] instance to the struct if required
     async fn __set_executor(&mut self, _: Arc<Executor>) {}
 }
@@ -205,6 +205,6 @@ pub trait Request {
 /// explicit result.
 impl Request for () {}
 
-impl<K, V> Request for HashMap<K, V> {}
+impl<K: Send, V: Send> Request for HashMap<K, V> {}
 
 impl Request for serde_json::Value {}

--- a/src/common.rs
+++ b/src/common.rs
@@ -18,7 +18,7 @@ pub(crate) use crunchyroll_rs_internal::Request;
 #[serde(bound = "T: Request + DeserializeOwned")]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
-pub struct V2BulkResult<T, M = serde_json::Map<String, serde_json::Value>>
+pub(crate) struct V2BulkResult<T, M = serde_json::Map<String, serde_json::Value>>
 where
     T: Default + DeserializeOwned + Request,
     M: Default + DeserializeOwned + Send,
@@ -175,20 +175,9 @@ impl<T: Default + DeserializeOwned + Request> Pagination<T> {
 #[serde(bound = "T: Request + DeserializeOwned")]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
-pub struct BulkResult<T: Default + DeserializeOwned + Request> {
+pub(crate) struct BulkResult<T: Default + DeserializeOwned + Request> {
     pub items: Vec<T>,
     pub total: u32,
-}
-
-/// Just like [`BulkResult`] but without [`BulkResult::total`] because some request does not have
-/// this field (but should?!).
-#[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
-#[request(executor(items))]
-#[serde(bound = "T: Request + DeserializeOwned")]
-#[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
-#[cfg_attr(not(feature = "__test_strict"), serde(default))]
-pub struct CrappyBulkResult<T: Default + DeserializeOwned + Request> {
-    pub items: Vec<T>,
 }
 
 /// The standard representation of images how the api returns them.

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,8 +1,12 @@
-use crate::Executor;
+use crate::{Executor, Result};
+use futures_util::{Stream, StreamExt};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
 pub(crate) use crunchyroll_rs_internal::Request;
 
@@ -25,6 +29,104 @@ where
 
     #[serde(default)]
     pub(crate) meta: M,
+}
+
+#[allow(clippy::type_complexity)]
+pub struct Pagination<T: Default + DeserializeOwned + Request> {
+    data: Vec<T>,
+
+    init: bool,
+    next_fn: Box<
+        dyn FnMut(
+            u32,
+            Arc<Executor>,
+            Vec<(String, String)>,
+        ) -> Pin<Box<dyn Future<Output = Result<(Vec<T>, u32)>> + Send + 'static>>,
+    >,
+    next_state: Option<Pin<Box<dyn Future<Output = Result<(Vec<T>, u32)>> + Send + 'static>>>,
+
+    fn_executor: Arc<Executor>,
+    fn_query: Vec<(String, String)>,
+
+    count: u32,
+    total: u32,
+}
+
+impl<T: Default + DeserializeOwned + Request> Stream for Pagination<T> {
+    type Item = Result<T>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.count < self.total || !self.init {
+            let this = self.get_mut();
+
+            if this.next_state.is_none() {
+                let f = this.next_fn.as_mut();
+                this.next_state = Some(f(
+                    this.count,
+                    this.fn_executor.clone(),
+                    this.fn_query.clone(),
+                ))
+            }
+
+            let fut = this.next_state.as_mut().unwrap();
+            match Pin::new(fut).poll(cx) {
+                Poll::Ready(result) => match result {
+                    Ok((t, total)) => {
+                        this.data = t;
+                        this.total = total;
+                        this.next_state = None;
+                    }
+                    Err(e) => return Poll::Ready(Some(Err(e))),
+                },
+                Poll::Pending => return Poll::Pending,
+            }
+
+            this.init = true;
+            this.count += 1;
+            Poll::Ready(Some(Ok(this.data.remove(0))))
+        } else {
+            Poll::Ready(None)
+        }
+    }
+}
+
+impl<T: Default + DeserializeOwned + Request> Unpin for Pagination<T> {}
+
+impl<T: Default + DeserializeOwned + Request> Pagination<T> {
+    pub(crate) fn new<F>(
+        pagination_fn: F,
+        executor: Arc<Executor>,
+        query_args: Vec<(String, String)>,
+    ) -> Self
+    where
+        F: FnMut(
+                u32,
+                Arc<Executor>,
+                Vec<(String, String)>,
+            )
+                -> Pin<Box<dyn Future<Output = Result<(Vec<T>, u32)>> + Send + 'static>>
+            + Send
+            + 'static,
+    {
+        Self {
+            data: vec![],
+            init: false,
+            next_fn: Box::new(pagination_fn),
+            next_state: None,
+            fn_executor: executor,
+            fn_query: query_args,
+            count: 0,
+            total: 0,
+        }
+    }
+
+    /// Return the total amount of items which can be fetched.
+    pub async fn total(&mut self) -> u32 {
+        if !self.init {
+            StreamExt::next(self).await;
+        }
+        self.total
+    }
 }
 
 /// Contains a variable amount of items and the maximum / total of item which are available.

--- a/src/crunchyroll.rs
+++ b/src/crunchyroll.rs
@@ -327,7 +327,7 @@ mod auth {
                 .post(endpoint)
                 .header(header::AUTHORIZATION, "Basic bm9haWhkZXZtXzZpeWcwYThsMHE6")
                 .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
-                .header(header::COOKIE, format!("etp_rt={}", etp_rt))
+                .header(header::COOKIE, format!("etp_rt={etp_rt}"))
                 .body(
                     serde_urlencoded::to_string([
                         ("grant_type", "etp_rt_cookie"),

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,11 +30,11 @@ pub enum CrunchyrollError {
 impl Display for CrunchyrollError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            CrunchyrollError::Internal(context) => write!(f, "{}", context),
-            CrunchyrollError::Request(context) => write!(f, "{}", context),
-            CrunchyrollError::Decode(context) => write!(f, "{}", context),
-            CrunchyrollError::Authentication(context) => write!(f, "{}", context),
-            CrunchyrollError::Input(context) => write!(f, "{}", context),
+            CrunchyrollError::Internal(context) => write!(f, "{context}"),
+            CrunchyrollError::Request(context) => write!(f, "{context}"),
+            CrunchyrollError::Decode(context) => write!(f, "{context}"),
+            CrunchyrollError::Authentication(context) => write!(f, "{context}"),
+            CrunchyrollError::Input(context) => write!(f, "{context}"),
         }
     }
 }
@@ -68,8 +68,7 @@ impl From<reqwest::Error> for CrunchyrollError {
             CrunchyrollError::Internal(context)
         } else {
             CrunchyrollError::Internal(CrunchyrollErrorContext::new(format!(
-                "Could not determine request error type - {}",
-                err
+                "Could not determine request error type - {err}"
             )))
         }
     }
@@ -94,13 +93,13 @@ impl Display for CrunchyrollErrorContext {
         let mut res = self.message.clone();
 
         if let Some(url) = &self.url {
-            res.push_str(&format!(" ({})", url));
+            res.push_str(&format!(" ({url})"));
         }
         if let Some(value) = &self.value {
-            res.push_str(&format!(": {}", value));
+            res.push_str(&format!(": {value}"));
         }
 
-        write!(f, "{}", res)
+        write!(f, "{res}")
     }
 }
 
@@ -202,7 +201,7 @@ pub(crate) fn is_request_error(value: Value) -> Result<()> {
                     e.code,
                     e.violated_constraints
                         .iter()
-                        .map(|(key, value)| format!("{}: {}", key, value))
+                        .map(|(key, value)| format!("{key}: {value}"))
                         .collect::<Vec<String>>()
                         .join(", ")
                 )
@@ -230,8 +229,7 @@ pub(crate) async fn check_request<T: DeserializeOwned>(url: String, resp: Respon
             CrunchyrollErrorContext::new(format!(
                 "Rate limit detected. {}",
                 retry_secs.map_or("Try again later".to_string(), |secs| format!(
-                    "Try again in {} seconds",
-                    secs
+                    "Try again in {secs} seconds"
                 ))
             ))
             .with_url(resp.url()),

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -1,5 +1,5 @@
 use crate::common::{Pagination, V2BulkResult, V2TypeBulkResult};
-use crate::media::{MediaType, SimilarOptions};
+use crate::media::MediaType;
 use crate::search::{BrowseOptions, BrowseSortType};
 use crate::{Crunchyroll, MediaCollection, Request, Series};
 use chrono::{DateTime, Utc};
@@ -79,8 +79,6 @@ pub struct SimilarFeed {
 
     #[serde(skip)]
     pub similar_id: String,
-    #[serde(skip)]
-    pub similar_options: SimilarOptions,
 }
 
 #[derive(Clone, Debug, Request)]
@@ -187,31 +185,11 @@ impl<'de> Deserialize<'de> for HomeFeed {
                             .ok_or_else(|| type_error("source_media_id", "string"))?
                             .to_string();
 
-                        let link = get_value("link")?
-                            .as_str()
-                            .ok_or_else(|| type_error("link", "string"))?
-                            .to_string();
-                        let query: Vec<(String, String)> =
-                            serde_urlencoded::from_str(link.split('?').last().unwrap())
-                                .map_err(|e| Error::custom(e.to_string()))?;
-
-                        let mut similar_options = SimilarOptions::default();
-                        for (key, value) in query {
-                            if key.as_str() == "n" {
-                                similar_options = similar_options.limit(
-                                    value
-                                        .parse::<u32>()
-                                        .map_err(|e| Error::custom(e.to_string()))?,
-                                )
-                            }
-                        }
-
                         let mut similar_feed: SimilarFeed = serde_json::from_value(
                             serde_json::to_value(as_map).map_err(map_serde_error)?,
                         )
                         .map_err(map_serde_error)?;
                         similar_feed.similar_id = id;
-                        similar_feed.similar_options = similar_options;
 
                         Ok(Self::SimilarTo(similar_feed))
                     }

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -1,4 +1,4 @@
-use crate::common::{Pagination, V2BulkResult};
+use crate::common::{Pagination, V2BulkResult, V2TypeBulkResult};
 use crate::media::{MediaType, SimilarOptions};
 use crate::search::{BrowseOptions, BrowseSortType};
 use crate::{Crunchyroll, MediaCollection, Request, Series};
@@ -237,14 +237,6 @@ impl<'de> Deserialize<'de> for HomeFeed {
     }
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Request)]
-struct NewsFeedResultProxy {
-    #[serde(rename = "type")]
-    news_type: String,
-    total: u32,
-    items: Vec<NewsFeed>,
-}
-
 pub struct NewsFeedResult {
     pub top_news: Pagination<NewsFeed>,
     pub latest_news: Pagination<NewsFeed>,
@@ -300,7 +292,7 @@ impl Crunchyroll {
                 |start, executor, _| {
                     async move {
                         let endpoint = "https://www.crunchyroll.com/content/v2/discover/news_feed";
-                        let result: V2BulkResult<NewsFeedResultProxy> = executor
+                        let result: V2BulkResult<V2TypeBulkResult<NewsFeed>> = executor
                             .get(endpoint)
                             .query(&[("latest_news_n", "0")])
                             .query(&[("top_news_n", "20"), ("top_news_start", &start.to_string())])
@@ -310,7 +302,7 @@ impl Crunchyroll {
                         let top_news = result
                             .data
                             .into_iter()
-                            .find(|p| p.news_type == "top_news")
+                            .find(|p| p.result_type == "top_news")
                             .unwrap_or_default();
                         Ok((top_news.items, top_news.total))
                     }
@@ -323,7 +315,7 @@ impl Crunchyroll {
                 |start, executor, _| {
                     async move {
                         let endpoint = "https://www.crunchyroll.com/content/v2/discover/news_feed";
-                        let result: V2BulkResult<NewsFeedResultProxy> = executor
+                        let result: V2BulkResult<V2TypeBulkResult<NewsFeed>> = executor
                             .get(endpoint)
                             .query(&[("top_news_n", "0")])
                             .query(&[
@@ -336,7 +328,7 @@ impl Crunchyroll {
                         let top_news = result
                             .data
                             .into_iter()
-                            .find(|p| p.news_type == "top_news")
+                            .find(|p| p.result_type == "top_news")
                             .unwrap_or_default();
                         Ok((top_news.items, top_news.total))
                     }

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -260,7 +260,8 @@ impl Crunchyroll {
                 .boxed()
             },
             self.executor.clone(),
-            vec![],
+            None,
+            None,
         )
     }
 
@@ -292,7 +293,8 @@ impl Crunchyroll {
                     .boxed()
                 },
                 self.executor.clone(),
-                vec![],
+                None,
+                None,
             ),
             latest_news: Pagination::new(
                 |options| {
@@ -319,7 +321,8 @@ impl Crunchyroll {
                     .boxed()
                 },
                 self.executor.clone(),
-                vec![],
+                None,
+                None,
             ),
         }
     }
@@ -345,7 +348,8 @@ impl Crunchyroll {
                 .boxed()
             },
             self.executor.clone(),
-            vec![],
+            None,
+            None,
         )
     }
 }

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -264,15 +264,16 @@ impl Crunchyroll {
     /// Returns the home feed (shown when visiting the Crunchyroll index page).
     pub fn home_feed(&self) -> Pagination<HomeFeed> {
         Pagination::new(
-            |start, executor, _| {
+            |options| {
                 async move {
                     let endpoint = format!(
                         "https://www.crunchyroll.com/content/v2/discover/{}/home_feed",
-                        executor.details.account_id.clone()?
+                        options.executor.details.account_id.clone()?
                     );
-                    let result: V2BulkResult<HomeFeed> = executor
+                    let result: V2BulkResult<HomeFeed> = options
+                        .executor
                         .get(endpoint)
-                        .query(&[("n", "20"), ("start", &start.to_string())])
+                        .query(&[("n", options.page_size), ("start", options.start)])
                         .apply_locale_query()
                         .request()
                         .await?;
@@ -289,13 +290,17 @@ impl Crunchyroll {
     pub fn news_feed(&self) -> NewsFeedResult {
         NewsFeedResult {
             top_news: Pagination::new(
-                |start, executor, _| {
+                |options| {
                     async move {
                         let endpoint = "https://www.crunchyroll.com/content/v2/discover/news_feed";
-                        let result: V2BulkResult<V2TypeBulkResult<NewsFeed>> = executor
+                        let result: V2BulkResult<V2TypeBulkResult<NewsFeed>> = options
+                            .executor
                             .get(endpoint)
                             .query(&[("latest_news_n", "0")])
-                            .query(&[("top_news_n", "20"), ("top_news_start", &start.to_string())])
+                            .query(&[
+                                ("top_news_n", options.page_size),
+                                ("top_news_start", options.start),
+                            ])
                             .apply_locale_query()
                             .request()
                             .await?;
@@ -312,15 +317,16 @@ impl Crunchyroll {
                 vec![],
             ),
             latest_news: Pagination::new(
-                |start, executor, _| {
+                |options| {
                     async move {
                         let endpoint = "https://www.crunchyroll.com/content/v2/discover/news_feed";
-                        let result: V2BulkResult<V2TypeBulkResult<NewsFeed>> = executor
+                        let result: V2BulkResult<V2TypeBulkResult<NewsFeed>> = options
+                            .executor
                             .get(endpoint)
                             .query(&[("top_news_n", "0")])
                             .query(&[
-                                ("latest_news_n", "20"),
-                                ("latest_news_start", &start.to_string()),
+                                ("latest_news_n", options.page_size),
+                                ("latest_news_start", options.start),
                             ])
                             .apply_locale_query()
                             .request()
@@ -343,15 +349,16 @@ impl Crunchyroll {
     /// Returns recommended series or movies to watch.
     pub fn recommendations(&self) -> Pagination<MediaCollection> {
         Pagination::new(
-            |start, executor, _| {
+            |options| {
                 async move {
                     let endpoint = format!(
                         "https://www.crunchyroll.com/content/v2/discover/{}/recommendations",
-                        executor.details.account_id.clone()?
+                        options.executor.details.account_id.clone()?
                     );
-                    let result: V2BulkResult<MediaCollection> = executor
+                    let result: V2BulkResult<MediaCollection> = options
+                        .executor
                         .get(endpoint)
-                        .query(&[("n", "20"), ("start", &start.to_string())])
+                        .query(&[("n", options.page_size), ("start", options.start)])
                         .apply_locale_query()
                         .request()
                         .await?;

--- a/src/internal/serde.rs
+++ b/src/internal/serde.rs
@@ -22,8 +22,7 @@ impl<'de> Deserialize<'de> for EmptyJsonProxy {
             }
         }
         Err(Error::custom(format!(
-            "result must be empty object / map: '{}'",
-            value
+            "result must be empty object / map: '{value}'"
         )))
     }
 }

--- a/src/media/media.rs
+++ b/src/media/media.rs
@@ -41,9 +41,9 @@ fn split_locale_from_slug_title<S: AsRef<str>>(slug_title: S) -> (String, Locale
     (title, Locale::ja_JP)
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 pub trait Media {
-    async fn from_id<S: AsRef<str>>(crunchyroll: &Crunchyroll, id: S) -> Result<Self>
+    async fn from_id(crunchyroll: &Crunchyroll, id: impl AsRef<str> + Send) -> Result<Self>
     where
         Self: Sized;
 
@@ -720,7 +720,7 @@ impl_manual_media_deserialize! {
 macro_rules! impl_media_request {
     ($($media:ident)*) => {
         $(
-            #[async_trait::async_trait(?Send)]
+            #[async_trait::async_trait]
             impl Request for $media {
                 async fn __set_executor(&mut self, executor: Arc<Executor>) {
                     self.executor = executor;
@@ -740,7 +740,7 @@ impl_media_request! {
 macro_rules! impl_media_request_with_version {
     ($($media:ident)*) => {
         $(
-            #[async_trait::async_trait(?Send)]
+            #[async_trait::async_trait]
             impl Request for $media {
                 async fn __set_executor(&mut self, executor: Arc<Executor>) {
                     for version in self.versions.iter_mut() {
@@ -890,9 +890,9 @@ async fn request_media<T: Default + DeserializeOwned + Request>(
     Ok(result.data)
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 impl Media for Series {
-    async fn from_id<S: AsRef<str>>(crunchyroll: &Crunchyroll, id: S) -> Result<Self> {
+    async fn from_id(crunchyroll: &Crunchyroll, id: impl AsRef<str> + Send) -> Result<Self> {
         Ok(request_media(
             crunchyroll.executor.clone(),
             format!(
@@ -921,9 +921,9 @@ impl Media for Series {
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 impl Media for Season {
-    async fn from_id<S: AsRef<str>>(crunchyroll: &Crunchyroll, id: S) -> Result<Self> {
+    async fn from_id(crunchyroll: &Crunchyroll, id: impl AsRef<str> + Send) -> Result<Self> {
         Ok(request_media(
             crunchyroll.executor.clone(),
             format!(
@@ -962,9 +962,9 @@ impl Media for Season {
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 impl Media for Episode {
-    async fn from_id<S: AsRef<str>>(crunchyroll: &Crunchyroll, id: S) -> Result<Self> {
+    async fn from_id(crunchyroll: &Crunchyroll, id: impl AsRef<str> + Send) -> Result<Self> {
         Ok(request_media(
             crunchyroll.executor.clone(),
             format!(
@@ -997,9 +997,9 @@ impl Media for Episode {
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 impl Media for MovieListing {
-    async fn from_id<S: AsRef<str>>(crunchyroll: &Crunchyroll, id: S) -> Result<Self> {
+    async fn from_id(crunchyroll: &Crunchyroll, id: impl AsRef<str> + Send) -> Result<Self> {
         Ok(request_media(
             crunchyroll.executor.clone(),
             format!(
@@ -1013,9 +1013,9 @@ impl Media for MovieListing {
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 impl Media for Movie {
-    async fn from_id<S: AsRef<str>>(crunchyroll: &Crunchyroll, id: S) -> Result<Self> {
+    async fn from_id(crunchyroll: &Crunchyroll, id: impl AsRef<str> + Send) -> Result<Self> {
         Ok(request_media(
             crunchyroll.executor.clone(),
             format!(
@@ -1091,7 +1091,7 @@ impl Default for MediaCollection {
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 impl Request for MediaCollection {
     async fn __set_executor(&mut self, executor: Arc<Executor>) {
         match self {
@@ -1365,7 +1365,7 @@ impl_media_video! {
 }
 
 impl Crunchyroll {
-    pub async fn media_from_id<M: Media, S: AsRef<str>>(&self, id: S) -> Result<M> {
+    pub async fn media_from_id<M: Media>(&self, id: impl AsRef<str> + Send) -> Result<M> {
         M::from_id(self, id).await
     }
 

--- a/src/media/media.rs
+++ b/src/media/media.rs
@@ -899,7 +899,7 @@ macro_rules! impl_media_video_collection {
                 pub fn similar(&self) -> Pagination<MediaCollection> {
                     Pagination::new(|options| {
                         async move {
-                            let endpoint = format!("https://www.crunchyroll.com/content/v2/discover/{}/similar_to/{}", options.executor.details.account_id.clone()?, options.query.get(0).unwrap().0);
+                            let endpoint = format!("https://www.crunchyroll.com/content/v2/discover/{}/similar_to/{}", options.executor.details.account_id.clone()?, options.extra.get("id").unwrap());
                             let result: V2BulkResult<MediaCollection> = options
                                 .executor
                                 .get(endpoint)
@@ -910,7 +910,7 @@ macro_rules! impl_media_video_collection {
                             Ok((result.data, result.total))
                         }
                         .boxed()
-                    }, self.executor.clone(), vec![(self.id.clone(), self.id.clone())]) // the id as query is a little hack to pass the id to the closure
+                    }, self.executor.clone(), None, Some(vec![("id", self.id.clone())]))
                 }
             }
         )*

--- a/src/rating/comment.rs
+++ b/src/rating/comment.rs
@@ -268,10 +268,7 @@ async fn create_comment<S: AsRef<str>>(
     locale: &Locale,
     parent_id: Option<&String>,
 ) -> Result<Comment> {
-    let endpoint = format!(
-        "https://www.crunchyroll.com/talkbox/guestbooks/{}/comments",
-        video_id
-    );
+    let endpoint = format!("https://www.crunchyroll.com/talkbox/guestbooks/{video_id}/comments");
     let flags = if is_spoiler { vec!["spoiler"] } else { vec![] };
     executor
         .post(endpoint)

--- a/src/rating/comment.rs
+++ b/src/rating/comment.rs
@@ -1,6 +1,7 @@
-use crate::common::{BulkResult, Image};
+use crate::common::{BulkResult, Image, Pagination};
 use crate::{enum_values, options, EmptyJsonProxy, Executor, Locale, Request, Result};
 use chrono::{DateTime, Utc};
+use futures_util::FutureExt;
 use serde::de::Error;
 use serde::{Deserialize, Deserializer};
 use serde_json::json;
@@ -92,25 +93,35 @@ pub struct Comment {
     pub user_flags: Vec<CommentFlag>,
 }
 
-options! {
-    CommentOptions;
-    page(u32, "page") = Some(1),
-    size(u32, "page_size") = Some(10)
-}
-
 impl Comment {
     /// Return all replies to this comment.
-    pub async fn replies(&self, options: CommentOptions) -> Result<BulkResult<Comment>> {
-        let endpoint = format!(
-            "https://www.crunchyroll.com/talkbox/guestbooks/{}/comments/{}/replies",
-            self.guestbook_key, self.comment_id
-        );
-        self.executor
-            .get(endpoint)
-            .query(&options.into_query())
-            .apply_locale_query()
-            .request()
-            .await
+    pub fn replies(&self) -> Pagination<Comment> {
+        Pagination::new(
+            |options| {
+                async move {
+                    let endpoint = format!(
+                        "https://www.crunchyroll.com/talkbox/guestbooks/{}/comments/{}/replies",
+                        options.extra.get("guestbook_key").unwrap(),
+                        options.extra.get("comment_id").unwrap()
+                    );
+                    let result: BulkResult<Comment> = options
+                        .executor
+                        .get(endpoint)
+                        .query(&[("page", options.page), ("page_size", options.page_size)])
+                        .apply_locale_query()
+                        .request()
+                        .await?;
+                    Ok((result.items, result.total))
+                }
+                .boxed()
+            },
+            self.executor.clone(),
+            None,
+            Some(vec![
+                ("guestbook_key", self.guestbook_key.clone()),
+                ("comment_id", self.comment_id.clone()),
+            ]),
+        )
     }
 
     /// Reply to this comment.
@@ -229,8 +240,6 @@ enum_values! {
 
 options! {
     CommentsOptions;
-    page(u32, "page") = Some(1),
-    size(u32, "page_size") = Some(50),
     sort(CommentSortType, "sort") = Some(CommentSortType::Popularity)
 }
 
@@ -238,14 +247,22 @@ macro_rules! impl_comment {
     ($($s:path)*) => {
         $(
             impl $s {
-                pub async fn comments(&self, options: CommentsOptions) -> Result<BulkResult<Comment>> {
-                    let endpoint = format!("https://www.crunchyroll.com/talkbox/guestbooks/{}/comments", self.id);
-                    self.executor
-                        .get(endpoint)
-                        .query(&options.into_query())
-                        .apply_locale_query()
-                        .request()
-                        .await
+                pub fn comments(&self, options: CommentsOptions) -> Pagination<Comment> {
+                    Pagination::new(|options| {
+                        async move {
+                            let endpoint = format!("https://www.crunchyroll.com/talkbox/guestbooks/{}/comments", options.extra.get("id").unwrap());
+                            let result: BulkResult<Comment> = options
+                                .executor
+                                .get(endpoint)
+                                .query(&options.query)
+                                .query(&[("page", options.page), ("page_size", options.page_size)])
+                                .apply_locale_query()
+                                .request()
+                                .await?;
+                            Ok((result.items, result.total))
+                        }
+                        .boxed()
+                    }, self.executor.clone(), Some(options.into_query()), Some(vec![("id", self.id.clone())]))
                 }
 
                 pub async fn comment<S: AsRef<str>>(&self, message: S, is_spoiler: bool) -> Result<Comment> {

--- a/src/rating/review.rs
+++ b/src/rating/review.rs
@@ -221,8 +221,7 @@ where
         "no" => Ok(Some(false)),
         "" => Ok(None),
         _ => Err(Error::custom(format!(
-            "could not deserialize rating value '{}'",
-            value
+            "could not deserialize rating value '{value}'"
         ))),
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -85,7 +85,8 @@ mod browse {
                     .boxed()
                 },
                 self.executor.clone(),
-                options.into_query(),
+                Some(options.into_query()),
+                None,
             )
         }
 
@@ -132,7 +133,7 @@ mod query {
                             let result: V2BulkResult<V2TypeBulkResult<MediaCollection>> = options
                                 .executor
                                 .get(endpoint)
-                                .query(&options.query)
+                                .query(&[("q", options.extra.get("q").unwrap())])
                                 .query(&[("type", "top_results")])
                                 .query(&[("limit", options.page_size), ("start", options.start)])
                                 .apply_locale_query()
@@ -148,7 +149,8 @@ mod query {
                         .boxed()
                     },
                     self.executor.clone(),
-                    vec![("q".to_string(), query.as_ref().to_string())],
+                    None,
+                    Some(vec![("q", query.as_ref().to_string())]),
                 ),
                 series: Pagination::new(
                     |options| {
@@ -157,7 +159,7 @@ mod query {
                             let result: V2BulkResult<V2TypeBulkResult<Series>> = options
                                 .executor
                                 .get(endpoint)
-                                .query(&options.query)
+                                .query(&[("q", options.extra.get("q").unwrap())])
                                 .query(&[("type", "series")])
                                 .query(&[("limit", options.page_size), ("start", options.start)])
                                 .apply_locale_query()
@@ -173,7 +175,8 @@ mod query {
                         .boxed()
                     },
                     self.executor.clone(),
-                    vec![("q".to_string(), query.as_ref().to_string())],
+                    None,
+                    Some(vec![("q", query.as_ref().to_string())]),
                 ),
                 movie_listing: Pagination::new(
                     |options| {
@@ -182,7 +185,7 @@ mod query {
                             let result: V2BulkResult<V2TypeBulkResult<MovieListing>> = options
                                 .executor
                                 .get(endpoint)
-                                .query(&options.query)
+                                .query(&[("q", options.extra.get("q").unwrap())])
                                 .query(&[("type", "movie_listing")])
                                 .query(&[("limit", options.page_size), ("start", options.start)])
                                 .apply_locale_query()
@@ -198,7 +201,8 @@ mod query {
                         .boxed()
                     },
                     self.executor.clone(),
-                    vec![("q".to_string(), query.as_ref().to_string())],
+                    None,
+                    Some(vec![("q", query.as_ref().to_string())]),
                 ),
                 episode: Pagination::new(
                     |options| {
@@ -207,7 +211,7 @@ mod query {
                             let result: V2BulkResult<V2TypeBulkResult<Episode>> = options
                                 .executor
                                 .get(endpoint)
-                                .query(&options.query)
+                                .query(&[("q", options.extra.get("q").unwrap())])
                                 .query(&[("type", "episode")])
                                 .query(&[("limit", options.page_size), ("start", options.start)])
                                 .apply_locale_query()
@@ -223,7 +227,8 @@ mod query {
                         .boxed()
                     },
                     self.executor.clone(),
-                    vec![("q".to_string(), query.as_ref().to_string())],
+                    None,
+                    Some(vec![("q", query.as_ref().to_string())]),
                 ),
             }
         }

--- a/tests/test_comments.rs
+++ b/tests/test_comments.rs
@@ -8,7 +8,7 @@ mod utils;
 static COMMENT: Store<Comment> = Store::new(|| {
     Box::pin(async {
         let crunchy = SESSION.get().await?;
-        let episode: Episode = crunchy.media_from_id("GRDKJZ81Y", None).await.unwrap();
+        let episode: Episode = crunchy.media_from_id("GRDKJZ81Y").await.unwrap();
         Ok(episode
             .comments(CommentsOptions::default())
             .next()

--- a/tests/test_comments.rs
+++ b/tests/test_comments.rs
@@ -1,27 +1,30 @@
 use crate::utils::{Store, SESSION};
-use crunchyroll_rs::common::BulkResult;
 use crunchyroll_rs::rating::{Comment, CommentFlag, CommentsOptions};
 use crunchyroll_rs::Episode;
+use futures_util::StreamExt;
 
 mod utils;
 
-static COMMENTS: Store<BulkResult<Comment>> = Store::new(|| {
+static COMMENT: Store<Comment> = Store::new(|| {
     Box::pin(async {
         let crunchy = SESSION.get().await?;
         let episode: Episode = crunchy.media_from_id("GRDKJZ81Y", None).await.unwrap();
-        Ok(episode.comments(CommentsOptions::default()).await?)
+        Ok(episode
+            .comments(CommentsOptions::default())
+            .next()
+            .await
+            .unwrap()?)
     })
 });
 
 #[tokio::test]
 async fn comments() {
-    assert_result!(COMMENTS.get().await)
+    assert_result!(COMMENT.get().await)
 }
 
 #[tokio::test]
 async fn comment_flag() {
-    let mut comments = COMMENTS.get().await.unwrap().clone();
-    let comment = comments.items.get_mut(0).unwrap();
+    let mut comment = COMMENT.get().await.unwrap().clone();
 
     assert_result!(
         comment

--- a/tests/test_feed.rs
+++ b/tests/test_feed.rs
@@ -1,15 +1,14 @@
 use crate::utils::{Store, SESSION};
-use crunchyroll_rs::feed::{HomeFeed, HomeFeedOptions, NewsFeedOptions, RecommendationOptions};
+use crunchyroll_rs::feed::HomeFeed;
+use futures_util::StreamExt;
 
 mod utils;
 
 static HOME_FEED: Store<HomeFeed> = Store::new(|| {
     Box::pin(async {
         let crunchy = SESSION.get().await?;
-        let home_feed_items = crunchy
-            .home_feed(HomeFeedOptions::default().limit(100))
-            .await?;
-        let home_feed = home_feed_items.data.get(0).unwrap().clone();
+        let mut home_feed_items = crunchy.home_feed();
+        let home_feed = home_feed_items.next().await.unwrap()?;
         Ok(home_feed)
     })
 });
@@ -21,24 +20,25 @@ async fn home_feed_by_id() {
 
 #[tokio::test]
 async fn news_feed() {
-    assert_result!(
-        SESSION
-            .get()
-            .await
-            .unwrap()
-            .news_feed(NewsFeedOptions::default())
-            .await
-    )
+    assert_result!(SESSION
+        .get()
+        .await
+        .unwrap()
+        .news_feed()
+        .latest_news
+        .next()
+        .await
+        .unwrap())
 }
 
 #[tokio::test]
 async fn recommendations() {
-    assert_result!(
-        SESSION
-            .get()
-            .await
-            .unwrap()
-            .recommendations(RecommendationOptions::default())
-            .await
-    )
+    assert_result!(SESSION
+        .get()
+        .await
+        .unwrap()
+        .recommendations()
+        .next()
+        .await
+        .unwrap())
 }

--- a/tests/test_review.rs
+++ b/tests/test_review.rs
@@ -1,7 +1,7 @@
 use crate::utils::{Store, SESSION};
-use crunchyroll_rs::common::BulkResult;
 use crunchyroll_rs::rating::{RatingStar, Review, ReviewOptions};
 use crunchyroll_rs::Series;
+use futures_util::StreamExt;
 
 mod utils;
 
@@ -12,11 +12,11 @@ static SERIES: Store<Series> = Store::new(|| {
         Ok(series)
     })
 });
-static REVIEWS: Store<BulkResult<Review>> = Store::new(|| {
+static REVIEW: Store<Review> = Store::new(|| {
     Box::pin(async {
         let series = SERIES.get().await?;
-        let review = series.reviews(ReviewOptions::default()).await?;
-        Ok(review)
+        let mut review = series.reviews(ReviewOptions::default())?;
+        Ok(review.next().await.unwrap()?)
     })
 });
 
@@ -39,5 +39,5 @@ async fn rate() {
 
 #[tokio::test]
 async fn reviews() {
-    assert_result!(REVIEWS.get().await)
+    assert_result!(REVIEW.get().await)
 }

--- a/tests/test_search.rs
+++ b/tests/test_search.rs
@@ -1,6 +1,6 @@
 use crate::utils::SESSION;
-use crunchyroll_rs::search::{BrowseOptions, QueryOptions, QueryType};
 use crunchyroll_rs::Locale;
+use futures_util::stream::StreamExt;
 
 mod utils;
 
@@ -8,66 +8,22 @@ mod utils;
 async fn by_browse() {
     let crunchy = SESSION.get().await.unwrap();
 
-    let default_result = crunchy.browse(Default::default()).await;
-    assert_result!(default_result);
-
-    let zero_limit_result = crunchy.browse(BrowseOptions::default().limit(0)).await;
-    assert_result!(zero_limit_result);
+    assert_result!(crunchy.browse(Default::default()).next().await.unwrap());
 }
 
 #[tokio::test]
 async fn by_query() {
     let crunchy = SESSION.get().await.unwrap();
 
-    let default_result = crunchy.query("darling", Default::default()).await;
-    assert_result!(default_result);
-
-    let zero_limit_result = crunchy
-        .query("test", QueryOptions::default().limit(0))
-        .await;
-    assert_result!(zero_limit_result);
-    let zero_limit_result_unwrapped = zero_limit_result.unwrap();
-    assert!(
-        zero_limit_result_unwrapped.top_results.is_none(),
-        "'top_results' is not None"
-    );
-    assert!(
-        zero_limit_result_unwrapped.series.is_none(),
-        "'series' is not None"
-    );
-    assert!(
-        zero_limit_result_unwrapped.movie_listing.is_none(),
-        "'movie_listing' is not None"
-    );
-    assert!(
-        zero_limit_result_unwrapped.episode.is_none(),
-        "'episode' is not None"
-    );
-
-    let series_result = crunchy
-        .query(
-            "test",
-            QueryOptions::default().result_type(QueryType::Series),
-        )
-        .await;
-    assert_result!(series_result);
-    let series_result_unwrapped = series_result.unwrap();
-    assert!(
-        series_result_unwrapped.top_results.is_none(),
-        "'top_results' is not None"
-    );
-    assert!(
-        series_result_unwrapped.series.is_some(),
-        "'series' is not Some"
-    );
-    assert!(
-        series_result_unwrapped.movie_listing.is_none(),
-        "'movie_listing' is not None"
-    );
-    assert!(
-        series_result_unwrapped.episode.is_none(),
-        "'episode' is not None"
-    );
+    let mut default_result = crunchy.query("darling");
+    assert_result!(default_result.top_results.next().await.unwrap());
+    assert_result!(default_result.series.next().await.unwrap());
+    // movie listings might or might be not present across different countries for this search term
+    // so this is a workaround to keep the test passing
+    if let Some(result) = default_result.movie_listing.next().await {
+        assert_result!(result)
+    }
+    assert_result!(default_result.episode.next().await.unwrap())
 }
 
 #[tokio::test]

--- a/tests/test_search.rs
+++ b/tests/test_search.rs
@@ -1,6 +1,6 @@
 use crate::utils::SESSION;
 use crunchyroll_rs::Locale;
-use futures_util::stream::StreamExt;
+use futures_util::StreamExt;
 
 mod utils;
 

--- a/tests/test_series.rs
+++ b/tests/test_series.rs
@@ -1,7 +1,7 @@
 use crate::utils::Store;
 use crate::utils::SESSION;
-use crunchyroll_rs::media::SimilarOptions;
 use crunchyroll_rs::Series;
+use futures_util::StreamExt;
 
 mod utils;
 
@@ -25,12 +25,5 @@ async fn series_seasons() {
 
 #[tokio::test]
 async fn series_similar() {
-    assert_result!(
-        SERIES
-            .get()
-            .await
-            .unwrap()
-            .similar(SimilarOptions::default())
-            .await
-    )
+    assert_result!(SERIES.get().await.unwrap().similar().next().await.unwrap())
 }

--- a/tests/utils/session.rs
+++ b/tests/utils/session.rs
@@ -17,7 +17,7 @@ pub static SESSION: Store<Crunchyroll> = Store::new(|| {
                 .login_with_etp_rt(token)
                 .await
                 .unwrap(),
-            _ => panic!("invalid session '{}'", raw_session),
+            _ => panic!("invalid session '{raw_session}'"),
         };
 
         Ok(crunchy)
@@ -28,11 +28,9 @@ pub async fn set_session(crunchy: Crunchyroll) -> anyhow::Result<()> {
     match crunchy.session_token().await {
         SessionToken::RefreshToken(refresh_token) => Ok(set_store(
             "session".into(),
-            format!("refresh_token:{}", refresh_token),
+            format!("refresh_token:{refresh_token}"),
         )?),
-        SessionToken::EtpRt(etp_rt) => {
-            Ok(set_store("session".into(), format!("etp_rt:{}", etp_rt))?)
-        }
+        SessionToken::EtpRt(etp_rt) => Ok(set_store("session".into(), format!("etp_rt:{etp_rt}"))?),
         SessionToken::Anonymous => Ok(()),
     }
 }

--- a/tests/utils/store.rs
+++ b/tests/utils/store.rs
@@ -51,18 +51,18 @@ impl<T> Store<T> {
 }
 
 pub fn get_store(key: String) -> Result<String, std::io::Error> {
-    let path = env::temp_dir().join(format!(".crunchyroll-rs.{}", key));
+    let path = env::temp_dir().join(format!(".crunchyroll-rs.{key}"));
     fs::read_to_string(path)
 }
 
 pub fn set_store(key: String, value: String) -> Result<(), std::io::Error> {
-    let path = env::temp_dir().join(format!(".crunchyroll-rs.{}", key));
+    let path = env::temp_dir().join(format!(".crunchyroll-rs.{key}"));
     fs::write(path, value)?;
     Ok(())
 }
 
 pub fn has_store(key: String) -> bool {
     env::temp_dir()
-        .join(format!(".crunchyroll-rs.{}", key))
+        .join(format!(".crunchyroll-rs.{key}"))
         .exists()
 }


### PR DESCRIPTION
This PR adds pagination support. Until now, the number of results on pagination endpoints (e.g. `Crunchyroll::browse`) must be specified manually. The `Pagination` struct takes over this process. With the help of [`future_util::stream::Stream`](https://docs.rs/futures-util/*/futures_util/stream/trait.Stream.html) you can iterate over a pagination result and it will fetch the data as required. You might have to add [`futures_util`](https://docs.rs/futures-util) to your dependencies and use [`future_util::stream::Stream`](https://docs.rs/futures-util/*/futures_util/stream/trait.Stream.html) to gain access to some functions.

Functions which are returning `Pagination` now:
- Comments: `Episode::comments`, `Movie::comments`, `Comment::replies`
- Feed: `Crunchyroll::home_feed`, `Crunchyroll::news_feed`, `Crunchyroll::recommendations`
- Media: `Series::similar`, `MovieListing::similar`
- Reviews: `Series::reviews`, `MovieListing::reviews`
- Search: `Crunchyroll::browse`, `Crunchyroll::query`

This PR also updates the `format!` macro to use inlined arguments.