### PR TITLE
Make preferred audio locale global

### DIFF
--- a/examples/search-series.rs
+++ b/examples/search-series.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<()> {
             "Queried series {} which has {} seasons",
             series.title, series.season_count
         );
-        let seasons = series.seasons(None).await?;
+        let seasons = series.seasons().await?;
         for season in seasons {
             println!(
                 "Found season {} with audio locale(s) {}",

--- a/src/categories.rs
+++ b/src/categories.rs
@@ -1,6 +1,6 @@
 use crate::common::{Image, V2BulkResult};
+use crate::Result;
 use crate::{enum_values, Crunchyroll, Locale, Request};
-use crate::{options, Result};
 use serde::Deserialize;
 
 enum_values! {
@@ -63,23 +63,13 @@ pub struct CategoryInformation {
     pub localization: CategoryInformationLocalization,
 }
 
-options! {
-    CategoryInformationOptions;
-    /// Preferred audio language.
-    preferred_audio_language(Locale, "preferred_audio_language") = None
-}
-
 impl Crunchyroll {
     /// Returns all video categories.
-    pub async fn categories(
-        &self,
-        options: CategoryInformationOptions,
-    ) -> Result<Vec<CategoryInformation>> {
+    pub async fn categories(&self) -> Result<Vec<CategoryInformation>> {
         let endpoint = "https://www.crunchyroll.com/content/v2/discover/categories";
         Ok(self
             .executor
             .get(endpoint)
-            .query(&options.into_query())
             .apply_locale_query()
             .request::<V2BulkResult<CategoryInformation>>()
             .await?

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -253,6 +253,7 @@ impl Crunchyroll {
                         .get(endpoint)
                         .query(&[("n", options.page_size), ("start", options.start)])
                         .apply_locale_query()
+                        .apply_preferred_audio_locale_query()
                         .request()
                         .await?;
                     Ok((result.data, result.total))
@@ -281,6 +282,7 @@ impl Crunchyroll {
                                 ("top_news_start", options.start),
                             ])
                             .apply_locale_query()
+                            .apply_preferred_audio_locale_query()
                             .request()
                             .await?;
                         let top_news = result
@@ -309,6 +311,7 @@ impl Crunchyroll {
                                 ("latest_news_start", options.start),
                             ])
                             .apply_locale_query()
+                            .apply_preferred_audio_locale_query()
                             .request()
                             .await?;
                         let top_news = result
@@ -341,6 +344,7 @@ impl Crunchyroll {
                         .get(endpoint)
                         .query(&[("n", options.page_size), ("start", options.start)])
                         .apply_locale_query()
+                        .apply_preferred_audio_locale_query()
                         .request()
                         .await?;
                     Ok((result.data, result.total))

--- a/src/list/watchlist.rs
+++ b/src/list/watchlist.rs
@@ -17,13 +17,13 @@ pub struct WatchlistEntry {
     executor: Arc<Executor>,
 
     pub new: bool,
-    pub new_content: bool,
 
     pub is_favorite: bool,
 
-    pub playhead: u32,
     pub never_watched: bool,
-    pub completion_status: bool,
+    pub fully_watched: bool,
+
+    pub playhead: u32,
 
     /// Should only be [`MediaCollection::Series`] or [`MediaCollection::MovieListing`].
     pub panel: MediaCollection,

--- a/src/search.rs
+++ b/src/search.rs
@@ -59,9 +59,7 @@ mod browse {
         /// Specifies how the entries should be sorted.
         sort(BrowseSortType, "sort") = Some(BrowseSortType::NewlyAdded),
         /// Specifies the media type of the entries.
-        media_type(MediaType, "type") = None,
-        /// Preferred audio language.
-        preferred_audio_language(Locale, "preferred_audio_language") = None
+        media_type(MediaType, "type") = None
     }
 
     impl Crunchyroll {
@@ -78,6 +76,8 @@ mod browse {
                             .get(endpoint)
                             .query(&options.query)
                             .query(&[("n", options.page_size), ("start", options.start)])
+                            .apply_locale_query()
+                            .apply_preferred_audio_locale_query()
                             .request::<V2BulkResult<MediaCollection>>()
                             .await?;
                         Ok((result.data, result.total))

--- a/tests/test_categories.rs
+++ b/tests/test_categories.rs
@@ -1,11 +1,9 @@
 use crate::utils::SESSION;
-use crunchyroll_rs::categories::CategoryInformationOptions;
 
 mod utils;
 
 #[tokio::test]
 async fn categories() {
     let crunchy = SESSION.get().await.unwrap();
-    let options = CategoryInformationOptions::default();
-    assert_result!(crunchy.categories(options.clone()).await)
+    assert_result!(crunchy.categories().await)
 }

--- a/tests/test_episode.rs
+++ b/tests/test_episode.rs
@@ -56,26 +56,26 @@ async fn episode_set_playhead() {
 async fn episode_some_previous() {
     let episode = END_EPISODE.get().await.unwrap();
 
-    assert_result!(episode.previous(None).await)
+    assert_result!(episode.previous().await)
 }
 
 #[tokio::test]
 async fn episode_none_previous() {
     let episode = START_EPISODE.get().await.unwrap();
 
-    assert_result!(episode.previous(None).await)
+    assert_result!(episode.previous().await)
 }
 
 #[tokio::test]
 async fn episode_some_next() {
     let episode = START_EPISODE.get().await.unwrap();
 
-    assert_result!(episode.next(None).await)
+    assert_result!(episode.next().await)
 }
 
 #[tokio::test]
 async fn episode_none_next() {
     let episode = END_EPISODE.get().await.unwrap();
 
-    assert_result!(episode.next(None).await)
+    assert_result!(episode.next().await)
 }

--- a/tests/test_movie_listing.rs
+++ b/tests/test_movie_listing.rs
@@ -19,5 +19,5 @@ async fn movie_listing_from_id() {
 
 #[tokio::test]
 async fn movies() {
-    assert_result!(MOVIE_LISTING.get().await.unwrap().movies(None).await)
+    assert_result!(MOVIE_LISTING.get().await.unwrap().movies().await)
 }

--- a/tests/test_season.rs
+++ b/tests/test_season.rs
@@ -18,5 +18,5 @@ async fn season_from_id() {
 
 #[tokio::test]
 async fn season_episodes() {
-    assert_result!(SEASON.get().await.unwrap().episodes(None).await)
+    assert_result!(SEASON.get().await.unwrap().episodes().await)
 }

--- a/tests/test_series.rs
+++ b/tests/test_series.rs
@@ -20,7 +20,7 @@ async fn series_from_id() {
 
 #[tokio::test]
 async fn series_seasons() {
-    assert_result!(SERIES.get().await.unwrap().seasons(None).await)
+    assert_result!(SERIES.get().await.unwrap().seasons().await)
 }
 
 #[tokio::test]

--- a/tests/test_watch_history.rs
+++ b/tests/test_watch_history.rs
@@ -1,11 +1,16 @@
 use crate::utils::SESSION;
 mod utils;
+use crunchyroll_rs::list::WatchHistoryEntry;
 use futures_util::StreamExt;
 
 #[tokio::test]
 async fn watch_history() {
     let crunchy = SESSION.get().await.unwrap();
-    assert_result!(crunchy.watch_history().next().await.unwrap())
+    assert_result!(crunchy
+        .watch_history()
+        .next()
+        .await
+        .unwrap_or(Ok(WatchHistoryEntry::default())))
 }
 
 #[tokio::test]


### PR DESCRIPTION
This PR adds the `CrunchyrollBuilder::preferred_audio_locale` function to set the preferred audio locale globally/for the current struct instance. Some functions took this value as argument in the past; the preferred audio argument of this functions are removed now.

Affected functions: `BrowseOptions::preferred_audio_locale`, `Series::seasons`, `Season::episodes`, `Episode::next`, `Episode::previous`, `MovieListing::movies`, `Movie::next`, `Movie::previous`.