### PR TITLE
Add serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ hls-stream = ["aes", "cbc", "m3u8-rs"]
 dash-stream = ["dash-mpd"]
 # Add functionality to parse Crunchyroll urls.
 parse = ["lazy_static", "regex"]
+# Add functionality to serialize most structs.
+serialize = []
 # Add various stabilizations as Crunchyroll delivers wrong api results in some cases.
 experimental-stabilizations = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,6 @@ hls-stream = ["aes", "cbc", "m3u8-rs"]
 dash-stream = ["dash-mpd"]
 # Add functionality to parse Crunchyroll urls.
 parse = ["lazy_static", "regex"]
-# Add functionality to serialize most structs.
-serialize = []
 # Add various stabilizations as Crunchyroll delivers wrong api results in some cases.
 experimental-stabilizations = []
 

--- a/src/account.rs
+++ b/src/account.rs
@@ -2,15 +2,14 @@
 
 use crate::{options, Crunchyroll, EmptyJsonProxy, Executor, Locale, Request, Result};
 use chrono::{DateTime, Utc};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::sync::Arc;
 
 /// Account data of the currently logged in user.
 #[allow(dead_code)]
-#[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Deserialize, Serialize, smart_default::SmartDefault, Request)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct Account {
@@ -256,19 +255,17 @@ fn mature_content_flag_manga<'de, D: serde::Deserializer<'de>>(
 
 mod wallpaper {
     use crate::{Crunchyroll, Request, Result};
-    use serde::Deserialize;
+    use serde::{Deserialize, Serialize};
 
     /// Wallpaper which are shown at the top of your Crunchyroll profile.
-    #[derive(Clone, Debug, Default, Deserialize, Request)]
-    #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+    #[derive(Clone, Debug, Default, Deserialize, Serialize, Request)]
     #[serde(from = "String")]
     #[cfg_attr(not(feature = "__test_strict"), serde(default))]
     pub struct Wallpaper {
         pub name: String,
     }
 
-    #[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
-    #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+    #[derive(Clone, Debug, Deserialize, Serialize, smart_default::SmartDefault, Request)]
     #[request(executor(items))]
     #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
     #[cfg_attr(not(feature = "__test_strict"), serde(default))]

--- a/src/account.rs
+++ b/src/account.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 /// Account data of the currently logged in user.
 #[allow(dead_code)]
 #[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct Account {
@@ -259,6 +260,7 @@ mod wallpaper {
 
     /// Wallpaper which are shown at the top of your Crunchyroll profile.
     #[derive(Clone, Debug, Default, Deserialize, Request)]
+    #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
     #[serde(from = "String")]
     #[cfg_attr(not(feature = "__test_strict"), serde(default))]
     pub struct Wallpaper {
@@ -266,6 +268,7 @@ mod wallpaper {
     }
 
     #[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
+    #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
     #[request(executor(items))]
     #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
     #[cfg_attr(not(feature = "__test_strict"), serde(default))]

--- a/src/categories.rs
+++ b/src/categories.rs
@@ -34,6 +34,7 @@ impl From<CategoryInformation> for Category {
 
 /// Images for [`CategoryInformation`].
 #[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct CategoryInformationImages {
@@ -43,6 +44,7 @@ pub struct CategoryInformationImages {
 
 /// Human readable text about a category.
 #[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct CategoryInformationLocalization {
@@ -53,6 +55,7 @@ pub struct CategoryInformationLocalization {
 
 /// A anime category / genre.
 #[derive(Clone, Debug, Default, Deserialize, Request)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct CategoryInformation {

--- a/src/categories.rs
+++ b/src/categories.rs
@@ -3,7 +3,7 @@
 use crate::common::{Image, V2BulkResult};
 use crate::Result;
 use crate::{enum_values, Crunchyroll, Locale, Request};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 enum_values! {
     /// Video categories / genres.
@@ -33,8 +33,7 @@ impl From<CategoryInformation> for Category {
 }
 
 /// Images for [`CategoryInformation`].
-#[derive(Clone, Debug, Default, Deserialize)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct CategoryInformationImages {
@@ -43,8 +42,7 @@ pub struct CategoryInformationImages {
 }
 
 /// Human readable text about a category.
-#[derive(Clone, Debug, Default, Deserialize)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct CategoryInformationLocalization {
@@ -54,8 +52,7 @@ pub struct CategoryInformationLocalization {
 }
 
 /// A anime category / genre.
-#[derive(Clone, Debug, Default, Deserialize, Request)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Request)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct CategoryInformation {

--- a/src/common.rs
+++ b/src/common.rs
@@ -3,7 +3,7 @@
 use crate::{Executor, Result};
 use futures_util::{Stream, StreamExt};
 use serde::de::DeserializeOwned;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::future::Future;
 use std::pin::Pin;
@@ -184,8 +184,7 @@ pub(crate) struct BulkResult<T: Default + DeserializeOwned + Request> {
 }
 
 /// The standard representation of images how the api returns them.
-#[derive(Clone, Debug, Default, Deserialize)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct Image {

--- a/src/common.rs
+++ b/src/common.rs
@@ -185,6 +185,7 @@ pub(crate) struct BulkResult<T: Default + DeserializeOwned + Request> {
 
 /// The standard representation of images how the api returns them.
 #[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct Image {

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Deserializer};
 
 /// Images for a [`FeedCarousel`].
 #[derive(Clone, Debug, Default, Deserialize, Request)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct FeedCarouselImages {
@@ -22,6 +23,7 @@ pub struct FeedCarouselImages {
 /// The carousel / sliding images showed at first when visiting crunchyroll.com
 #[allow(dead_code)]
 #[derive(Clone, Debug, Default, Deserialize, Request)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct FeedCarousel {
@@ -44,6 +46,7 @@ pub struct FeedCarousel {
 
 /// Images for a [`FeedBanner`].
 #[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct FeedBannerImages {
@@ -55,6 +58,7 @@ pub struct FeedBannerImages {
 
 /// A feed banner.
 #[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct FeedBanner {
     pub title: String,
 
@@ -68,6 +72,7 @@ pub struct FeedBanner {
 
 /// A feed containing multiple ids to different series.
 #[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct SeriesFeed {
     pub title: String,
 
@@ -79,6 +84,7 @@ pub struct SeriesFeed {
 
 /// A feed containing a id to a series or episode, depending on what you've watched in the past.
 #[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct SimilarFeed {
     pub title: String,
 
@@ -90,6 +96,7 @@ pub struct SimilarFeed {
 
 /// Items which can be shown on the home feed.
 #[derive(Clone, Debug, Request)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub enum HomeFeed {
     /// The feed at the top of the Crunchyroll website.
     CarouselFeed(Vec<FeedCarousel>),
@@ -290,6 +297,7 @@ pub struct NewsFeedResult {
 
 /// Crunchyroll news like new library anime, dubs, etc... .
 #[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct NewsFeed {

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -7,11 +7,10 @@ use crate::{Crunchyroll, MediaCollection, Request, Series};
 use chrono::{DateTime, Utc};
 use futures_util::FutureExt;
 use serde::de::Error;
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 
 /// Images for a [`FeedCarousel`].
-#[derive(Clone, Debug, Default, Deserialize, Request)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Request)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct FeedCarouselImages {
@@ -22,8 +21,7 @@ pub struct FeedCarouselImages {
 
 /// The carousel / sliding images showed at first when visiting crunchyroll.com
 #[allow(dead_code)]
-#[derive(Clone, Debug, Default, Deserialize, Request)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Request)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct FeedCarousel {
@@ -45,8 +43,7 @@ pub struct FeedCarousel {
 }
 
 /// Images for a [`FeedBanner`].
-#[derive(Clone, Debug, Default, Deserialize)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct FeedBannerImages {
@@ -57,8 +54,7 @@ pub struct FeedBannerImages {
 }
 
 /// A feed banner.
-#[derive(Clone, Debug, Default, Deserialize)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct FeedBanner {
     pub title: String,
 
@@ -71,8 +67,7 @@ pub struct FeedBanner {
 }
 
 /// A feed containing multiple ids to different series.
-#[derive(Clone, Debug, Default, Deserialize)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct SeriesFeed {
     pub title: String,
 
@@ -83,8 +78,7 @@ pub struct SeriesFeed {
 }
 
 /// A feed containing a id to a series or episode, depending on what you've watched in the past.
-#[derive(Clone, Debug, Default, Deserialize)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct SimilarFeed {
     pub title: String,
 
@@ -95,8 +89,7 @@ pub struct SimilarFeed {
 }
 
 /// Items which can be shown on the home feed.
-#[derive(Clone, Debug, Request)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Serialize, Request)]
 pub enum HomeFeed {
     /// The feed at the top of the Crunchyroll website.
     CarouselFeed(Vec<FeedCarousel>),
@@ -296,8 +289,7 @@ pub struct NewsFeedResult {
 }
 
 /// Crunchyroll news like new library anime, dubs, etc... .
-#[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Deserialize, Serialize, smart_default::SmartDefault, Request)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct NewsFeed {

--- a/src/internal/serde.rs
+++ b/src/internal/serde.rs
@@ -90,7 +90,6 @@ where
     Ok(Duration::milliseconds(i64::deserialize(deserializer)?))
 }
 
-#[cfg(feature = "serialize")]
 pub(crate) fn serialize_duration_to_millis<S>(
     duration: &Duration,
     serializer: S,

--- a/src/internal/serde.rs
+++ b/src/internal/serde.rs
@@ -90,6 +90,17 @@ where
     Ok(Duration::milliseconds(i64::deserialize(deserializer)?))
 }
 
+#[cfg(feature = "serialize")]
+pub(crate) fn serialize_duration_to_millis<S>(
+    duration: &Duration,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_i64(duration.num_milliseconds())
+}
+
 pub(crate) fn deserialize_try_from_string<'de, D, T: FromStr>(
     deserializer: D,
 ) -> Result<T, D::Error>

--- a/src/list/crunchylist.rs
+++ b/src/list/crunchylist.rs
@@ -2,13 +2,12 @@ use crate::common::V2BulkResult;
 use crate::error::CrunchyrollError;
 use crate::{Crunchyroll, EmptyJsonProxy, Executor, MediaCollection, Request, Result};
 use chrono::{DateTime, Utc};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::sync::Arc;
 
 /// A [`Crunchylist`] entry.
-#[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Deserialize, Serialize, smart_default::SmartDefault, Request)]
 #[request(executor(panel))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
@@ -45,8 +44,7 @@ impl CrunchylistEntry {
 }
 
 /// Representation of Crunchylists / custom lists you can create to store series or movies in.
-#[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Deserialize, Serialize, smart_default::SmartDefault, Request)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct Crunchylists {
@@ -102,8 +100,7 @@ impl Crunchylists {
 }
 
 /// A Crunchylist.
-#[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Deserialize, Serialize, smart_default::SmartDefault, Request)]
 #[request(executor(items))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
@@ -188,8 +185,7 @@ impl Crunchylist {
 
 /// Abstraction of [`Crunchylist`]. Use [`CrunchylistPreview::crunchylist`] to get the "real"
 /// [`Crunchylist`].
-#[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Deserialize, Serialize, smart_default::SmartDefault, Request)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct CrunchylistPreview {

--- a/src/list/crunchylist.rs
+++ b/src/list/crunchylist.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 /// A [`Crunchylist`] entry.
 #[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[request(executor(panel))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
@@ -45,6 +46,7 @@ impl CrunchylistEntry {
 
 /// Representation of Crunchylists / custom lists you can create to store series or movies in.
 #[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct Crunchylists {
@@ -101,6 +103,7 @@ impl Crunchylists {
 
 /// A Crunchylist.
 #[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[request(executor(items))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
@@ -186,6 +189,7 @@ impl Crunchylist {
 /// Abstraction of [`Crunchylist`]. Use [`CrunchylistPreview::crunchylist`] to get the "real"
 /// [`Crunchylist`].
 #[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct CrunchylistPreview {

--- a/src/list/watch_history.rs
+++ b/src/list/watch_history.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 
 /// Entry of your watchlist.
 #[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 #[request(executor(panel))]

--- a/src/list/watch_history.rs
+++ b/src/list/watch_history.rs
@@ -2,11 +2,10 @@ use crate::common::{Pagination, V2BulkResult};
 use crate::{Crunchyroll, EmptyJsonProxy, MediaCollection, Request, Result};
 use chrono::{DateTime, Utc};
 use futures_util::FutureExt;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Entry of your watchlist.
-#[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Deserialize, Serialize, smart_default::SmartDefault, Request)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 #[request(executor(panel))]

--- a/src/list/watchlist.rs
+++ b/src/list/watchlist.rs
@@ -4,13 +4,12 @@ use crate::{
     enum_values, options, Crunchyroll, EmptyJsonProxy, Executor, MediaCollection, Request, Result,
 };
 use chrono::{DateTime, Utc};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::sync::Arc;
 
 /// A item in your watchlist.
-#[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Deserialize, Serialize, smart_default::SmartDefault, Request)]
 #[request(executor(panel))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
@@ -60,8 +59,7 @@ impl WatchlistEntry {
 }
 
 /// A simplified version of [`WatchlistEntry`].
-#[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Deserialize, Serialize, smart_default::SmartDefault, Request)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct SimpleWatchlistEntry {

--- a/src/list/watchlist.rs
+++ b/src/list/watchlist.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 /// A item in your watchlist.
 #[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[request(executor(panel))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
@@ -60,6 +61,7 @@ impl WatchlistEntry {
 
 /// A simplified version of [`WatchlistEntry`].
 #[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct SimpleWatchlistEntry {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -124,6 +124,7 @@ macro_rules! options {
             #[$struct_attribute]
         )*
         #[derive(Clone, Debug)]
+        #[cfg_attr(feature = "serialize", derive(serde::Deserialize, serde::Serialize))]
         pub struct $name {
             $(
                 $(

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -123,8 +123,7 @@ macro_rules! options {
         $(
             #[$struct_attribute]
         )*
-        #[derive(Clone, Debug)]
-        #[cfg_attr(feature = "serialize", derive(serde::Deserialize, serde::Serialize))]
+        #[derive(Deserialize, Serialize, Clone, Debug)]
         pub struct $name {
             $(
                 $(

--- a/src/media/anime/episode.rs
+++ b/src/media/anime/episode.rs
@@ -31,6 +31,7 @@ pub(crate) struct EpisodeVersion {
 /// Metadata for an episode.
 #[allow(dead_code)]
 #[derive(Clone, Debug, Deserialize, smart_default::SmartDefault)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[serde(remote = "Self")]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
@@ -88,6 +89,7 @@ pub struct Episode {
 
     #[serde(alias = "duration_ms")]
     #[serde(deserialize_with = "crate::internal::serde::deserialize_millis_to_duration")]
+    #[serde(serialize_with = "crate::internal::serde::serialize_duration_to_millis")]
     #[default(Duration::milliseconds(0))]
     pub duration: Duration,
 
@@ -126,6 +128,7 @@ pub struct Episode {
     pub eligible_region: String,
 
     #[serde(default)]
+    #[serde(skip_serializing)]
     pub(crate) versions: Option<Vec<EpisodeVersion>>,
 
     #[cfg(feature = "__test_strict")]

--- a/src/media/anime/episode.rs
+++ b/src/media/anime/episode.rs
@@ -5,7 +5,7 @@ use crate::media::util::request_media;
 use crate::media::Media;
 use crate::{Crunchyroll, Locale, Result, Season, Series};
 use chrono::{DateTime, Duration, Utc};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[allow(dead_code)]
@@ -30,8 +30,7 @@ pub(crate) struct EpisodeVersion {
 
 /// Metadata for an episode.
 #[allow(dead_code)]
-#[derive(Clone, Debug, Deserialize, smart_default::SmartDefault)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Deserialize, Serialize, smart_default::SmartDefault)]
 #[serde(remote = "Self")]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]

--- a/src/media/anime/impl.rs
+++ b/src/media/anime/impl.rs
@@ -3,7 +3,7 @@ use crate::media::Media;
 use crate::{Episode, Locale, MediaCollection, Movie, MovieListing, Result, Season, Series};
 use chrono::{DateTime, Utc};
 use serde::de::{DeserializeOwned, Error};
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Map;
 
 /// Information about the intro of an [`Episode`] or [`Movie`].
@@ -35,8 +35,7 @@ pub(crate) struct VideoIntroResult {
 
 /// Media related to the media which queried this struct.
 #[allow(dead_code)]
-#[derive(Clone, Debug, Default, Deserialize, Request)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Request)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct RelatedMedia<T: Request + DeserializeOwned> {
@@ -71,8 +70,7 @@ where
 
 /// Information about the playhead of an [`Episode`] or [`Movie`].
 #[allow(dead_code)]
-#[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Deserialize, Serialize, smart_default::SmartDefault, Request)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct PlayheadInformation {
@@ -130,7 +128,6 @@ impl_manual_media_deserialize! {
 macro_rules! impl_manual_media_serialize {
     ($($media:ident)*) => {
         $(
-            #[cfg(feature = "serialize")]
             impl serde::Serialize for $media {
                 fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
                 where

--- a/src/media/anime/movie.rs
+++ b/src/media/anime/movie.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 /// Metadata for a movie.
 #[allow(dead_code)]
 #[derive(Clone, Debug, Deserialize, smart_default::SmartDefault)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[serde(remote = "Self")]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
@@ -34,15 +35,16 @@ pub struct Movie {
 
     #[serde(alias = "duration_ms")]
     #[serde(deserialize_with = "crate::internal::serde::deserialize_millis_to_duration")]
+    #[serde(serialize_with = "crate::internal::serde::serialize_duration_to_millis")]
     #[default(Duration::milliseconds(0))]
     pub duration: Duration,
 
     pub images: ThumbnailImages,
 
     #[default(DateTime::< Utc >::from(std::time::SystemTime::UNIX_EPOCH))]
-    free_available_date: DateTime<Utc>,
+    pub free_available_date: DateTime<Utc>,
     #[default(DateTime::< Utc >::from(std::time::SystemTime::UNIX_EPOCH))]
-    premium_available_date: DateTime<Utc>,
+    pub premium_available_date: DateTime<Utc>,
 
     pub is_subbed: bool,
     pub is_dubbed: bool,

--- a/src/media/anime/movie.rs
+++ b/src/media/anime/movie.rs
@@ -3,13 +3,12 @@ use crate::media::util::request_media;
 use crate::media::{Media, ThumbnailImages};
 use crate::{Crunchyroll, MovieListing, Result};
 use chrono::{DateTime, Duration, Utc};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 /// Metadata for a movie.
 #[allow(dead_code)]
-#[derive(Clone, Debug, Deserialize, smart_default::SmartDefault)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Deserialize, Serialize, smart_default::SmartDefault)]
 #[serde(remote = "Self")]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]

--- a/src/media/anime/movie_listing.rs
+++ b/src/media/anime/movie_listing.rs
@@ -4,7 +4,7 @@ use crate::media::util::request_media;
 use crate::media::{Media, PosterImages};
 use crate::{Crunchyroll, Locale, Movie, Result};
 use chrono::{DateTime, Utc};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[allow(dead_code)]
@@ -24,8 +24,7 @@ pub(crate) struct MovieListingVersion {
 
 /// Metadata for a movie listing.
 #[allow(dead_code)]
-#[derive(Clone, Debug, Deserialize, smart_default::SmartDefault)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Deserialize, Serialize, smart_default::SmartDefault)]
 #[serde(remote = "Self")]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]

--- a/src/media/anime/movie_listing.rs
+++ b/src/media/anime/movie_listing.rs
@@ -25,6 +25,7 @@ pub(crate) struct MovieListingVersion {
 /// Metadata for a movie listing.
 #[allow(dead_code)]
 #[derive(Clone, Debug, Deserialize, smart_default::SmartDefault)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[serde(remote = "Self")]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
@@ -81,6 +82,7 @@ pub struct MovieListing {
     pub availability_notes: String,
 
     #[serde(default)]
+    #[serde(skip_serializing)]
     pub(crate) versions: Option<Vec<MovieListingVersion>>,
 
     #[cfg(feature = "__test_strict")]

--- a/src/media/anime/season.rs
+++ b/src/media/anime/season.rs
@@ -3,7 +3,7 @@ use crate::media::anime::util::{parse_locale_from_slug_title, real_dedup_vec};
 use crate::media::util::request_media;
 use crate::media::Media;
 use crate::{Crunchyroll, Episode, Locale, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[allow(dead_code)]
@@ -23,9 +23,8 @@ pub(crate) struct SeasonVersion {
 
 /// Metadata for a season.
 #[allow(dead_code)]
-#[derive(Clone, Debug, Deserialize, smart_default::SmartDefault)]
+#[derive(Clone, Debug, Deserialize, Serialize, smart_default::SmartDefault)]
 #[serde(remote = "Self")]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct Season {

--- a/src/media/anime/season.rs
+++ b/src/media/anime/season.rs
@@ -25,6 +25,7 @@ pub(crate) struct SeasonVersion {
 #[allow(dead_code)]
 #[derive(Clone, Debug, Deserialize, smart_default::SmartDefault)]
 #[serde(remote = "Self")]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct Season {
@@ -56,6 +57,7 @@ pub struct Season {
     pub is_subbed: bool,
     pub is_dubbed: bool,
     pub is_simulcast: bool,
+    #[serde(skip_serializing)]
     audio_locale: Option<Locale>,
     /// Most of the time, like 99%, this contains only one locale. But sometimes Crunchyroll does
     /// weird stuff and marks a season which clearly has only one locale with two locales. See
@@ -72,6 +74,7 @@ pub struct Season {
     pub availability_notes: String,
 
     #[serde(default)]
+    #[serde(skip_serializing)]
     pub(crate) versions: Option<Vec<SeasonVersion>>,
 
     #[cfg(feature = "__test_strict")]

--- a/src/media/anime/series.rs
+++ b/src/media/anime/series.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 /// Metadata for a series.
 #[allow(dead_code)]
 #[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[serde(remote = "Self")]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]

--- a/src/media/anime/series.rs
+++ b/src/media/anime/series.rs
@@ -4,13 +4,12 @@ use crate::media::anime::util::real_dedup_vec;
 use crate::media::util::request_media;
 use crate::media::{Media, PosterImages};
 use crate::{Crunchyroll, Locale, Result, Season};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 /// Metadata for a series.
 #[allow(dead_code)]
-#[derive(Clone, Debug, Default, Deserialize)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(remote = "Self")]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]

--- a/src/media/media_collection.rs
+++ b/src/media/media_collection.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 /// specific media.
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub enum MediaCollection {
     Series(Series),
     Season(Season),

--- a/src/media/media_collection.rs
+++ b/src/media/media_collection.rs
@@ -6,15 +6,14 @@ use crate::{
     Concert, Crunchyroll, Episode, Movie, MovieListing, MusicVideo, Result, Season, Series,
 };
 use serde::de::Error;
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use std::sync::Arc;
 
 /// Collection of all media types. Useful in situations where [`Media`] can contain more than one
 /// specific media.
 #[allow(clippy::large_enum_variant)]
-#[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Serialize, Clone, Debug, PartialEq)]
 pub enum MediaCollection {
     Series(Series),
     Season(Season),

--- a/src/media/music/artist.rs
+++ b/src/media/music/artist.rs
@@ -5,12 +5,11 @@ use crate::media::util::request_media;
 use crate::media::{MusicGenre, MusicVideo, PosterImages};
 use crate::{Crunchyroll, Request, Result};
 use chrono::{DateTime, Duration, Utc};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 /// A preview / summary of an artist. Returned when requesting a [`MusicVideo`] or [`Concert`].
-#[derive(Clone, Debug, Default, Deserialize, Request)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Request)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct ArtistPreview {
@@ -37,8 +36,7 @@ impl ArtistPreview {
 
 /// Metadata for a music artist.
 #[allow(dead_code)]
-#[derive(Clone, Debug, Deserialize, Request, smart_default::SmartDefault)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Deserialize, Serialize, Request, smart_default::SmartDefault)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]

--- a/src/media/music/artist.rs
+++ b/src/media/music/artist.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 /// A preview / summary of an artist. Returned when requesting a [`MusicVideo`] or [`Concert`].
 #[derive(Clone, Debug, Default, Deserialize, Request)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct ArtistPreview {
@@ -37,6 +38,7 @@ impl ArtistPreview {
 /// Metadata for a music artist.
 #[allow(dead_code)]
 #[derive(Clone, Debug, Deserialize, Request, smart_default::SmartDefault)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
@@ -63,10 +65,12 @@ pub struct Artist {
 
     #[serde(alias = "totalConcertDurationMs")]
     #[serde(deserialize_with = "crate::internal::serde::deserialize_millis_to_duration")]
+    #[serde(serialize_with = "crate::internal::serde::serialize_duration_to_millis")]
     #[default(Duration::milliseconds(0))]
     pub total_concert_duration: Duration,
     #[serde(alias = "totalVideoDurationMs")]
     #[serde(deserialize_with = "crate::internal::serde::deserialize_millis_to_duration")]
+    #[serde(serialize_with = "crate::internal::serde::serialize_duration_to_millis")]
     #[default(Duration::milliseconds(0))]
     pub total_video_duration: Duration,
 

--- a/src/media/music/concert.rs
+++ b/src/media/music/concert.rs
@@ -5,12 +5,11 @@ use crate::media::{ArtistPreview, Media, MusicGenre, ThumbnailImages};
 use crate::{Crunchyroll, Request, Result};
 use chrono::{DateTime, Duration, Utc};
 use serde::de::{Error, IntoDeserializer};
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::sync::Arc;
 
 /// Metadata for a concert.
-#[derive(Clone, Debug, Deserialize, Request, smart_default::SmartDefault)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Deserialize, Serialize, Request, smart_default::SmartDefault)]
 #[request(executor(artist))]
 #[serde(rename_all = "camelCase")]
 #[serde(remote = "Self")]

--- a/src/media/music/concert.rs
+++ b/src/media/music/concert.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 /// Metadata for a concert.
 #[derive(Clone, Debug, Deserialize, Request, smart_default::SmartDefault)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[request(executor(artist))]
 #[serde(rename_all = "camelCase")]
 #[serde(remote = "Self")]
@@ -46,6 +47,7 @@ pub struct Concert {
 
     #[serde(alias = "durationMs")]
     #[serde(deserialize_with = "crate::internal::serde::deserialize_millis_to_duration")]
+    #[serde(serialize_with = "crate::internal::serde::serialize_duration_to_millis")]
     #[default(Duration::milliseconds(0))]
     pub duration: Duration,
     #[default(DateTime::<Utc>::from(std::time::SystemTime::UNIX_EPOCH))]

--- a/src/media/music/impl.rs
+++ b/src/media/music/impl.rs
@@ -4,7 +4,6 @@ use crate::{Concert, MusicVideo, Result};
 macro_rules! impl_manual_media_serialize {
     ($($media:ident)*) => {
         $(
-            #[cfg(feature = "serialize")]
             impl serde::Serialize for $media {
                 fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
                 where

--- a/src/media/music/impl.rs
+++ b/src/media/music/impl.rs
@@ -1,6 +1,26 @@
 use crate::media::Artist;
 use crate::{Concert, MusicVideo, Result};
 
+macro_rules! impl_manual_media_serialize {
+    ($($media:ident)*) => {
+        $(
+            #[cfg(feature = "serialize")]
+            impl serde::Serialize for $media {
+                fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    $media::serialize(self, serializer)
+                }
+            }
+        )*
+    }
+}
+
+impl_manual_media_serialize! {
+    Concert MusicVideo
+}
+
 macro_rules! impl_media_music {
     ($($media_music:ident)*) => {
         $(

--- a/src/media/music/mod.rs
+++ b/src/media/music/mod.rs
@@ -9,11 +9,10 @@ pub use concert::*;
 pub use music_video::*;
 
 use crate::Request;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// A music genre.
-#[derive(Clone, Debug, Default, Deserialize, Request)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Request)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]

--- a/src/media/music/mod.rs
+++ b/src/media/music/mod.rs
@@ -13,6 +13,7 @@ use serde::Deserialize;
 
 /// A music genre.
 #[derive(Clone, Debug, Default, Deserialize, Request)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]

--- a/src/media/music/music_video.rs
+++ b/src/media/music/music_video.rs
@@ -5,12 +5,11 @@ use crate::media::{ArtistPreview, Media, MusicGenre, ThumbnailImages};
 use crate::{Crunchyroll, MediaCollection, Request, Result};
 use chrono::{DateTime, Duration, Utc};
 use serde::de::{Error, IntoDeserializer};
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::sync::Arc;
 
 /// Metadata for a music video.
-#[derive(Clone, Debug, Deserialize, Request, smart_default::SmartDefault)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Deserialize, Serialize, Request, smart_default::SmartDefault)]
 #[request(executor(artist))]
 #[serde(rename_all = "camelCase")]
 #[serde(remote = "Self")]

--- a/src/media/music/music_video.rs
+++ b/src/media/music/music_video.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 /// Metadata for a music video.
 #[derive(Clone, Debug, Deserialize, Request, smart_default::SmartDefault)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[request(executor(artist))]
 #[serde(rename_all = "camelCase")]
 #[serde(remote = "Self")]
@@ -50,6 +51,7 @@ pub struct MusicVideo {
 
     #[serde(alias = "durationMs")]
     #[serde(deserialize_with = "crate::internal::serde::deserialize_millis_to_duration")]
+    #[serde(serialize_with = "crate::internal::serde::serialize_duration_to_millis")]
     #[default(Duration::milliseconds(0))]
     pub duration: Duration,
 

--- a/src/media/shared/image.rs
+++ b/src/media/shared/image.rs
@@ -4,6 +4,7 @@ use serde_json::{Map, Value};
 
 /// Images for a [`crate::Movie`] or [`crate::Concert`].
 #[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[serde(try_from = "Map<String, Value>")]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
@@ -33,6 +34,7 @@ impl TryFrom<Map<String, Value>> for ThumbnailImages {
 
 /// Images for [`Series`], [`MovieListing`] or [`crate::media::Artist`].
 #[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[serde(try_from = "Map<String, Value>")]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]

--- a/src/media/shared/image.rs
+++ b/src/media/shared/image.rs
@@ -1,10 +1,9 @@
 use crate::common::Image;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 /// Images for a [`crate::Movie`] or [`crate::Concert`].
-#[derive(Clone, Debug, Default, Deserialize)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(try_from = "Map<String, Value>")]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
@@ -33,8 +32,7 @@ impl TryFrom<Map<String, Value>> for ThumbnailImages {
 }
 
 /// Images for [`Series`], [`MovieListing`] or [`crate::media::Artist`].
-#[derive(Clone, Debug, Default, Deserialize)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(try_from = "Map<String, Value>")]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]

--- a/src/media/stream.rs
+++ b/src/media/stream.rs
@@ -2,7 +2,7 @@ use crate::common::V2BulkResult;
 use crate::error::CrunchyrollError;
 use crate::{Executor, Locale, Request, Result};
 use serde::de::Error;
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -61,8 +61,7 @@ pub(crate) struct StreamVersion {
 
 /// A video stream.
 #[allow(dead_code)]
-#[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Deserialize, Serialize, smart_default::SmartDefault, Request)]
 #[request(executor(subtitles))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
@@ -180,8 +179,7 @@ impl Stream {
 }
 
 /// Subtitle for streams.
-#[derive(Clone, Debug, Default, Deserialize, Request)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Request)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct Subtitle {
@@ -203,8 +201,7 @@ impl Subtitle {
 }
 
 /// A [`Stream`] variant.
-#[derive(Clone, Debug, Default, Deserialize)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct Variant {
@@ -218,8 +215,7 @@ pub struct Variant {
 
 /// Stream variants for a [`Stream`].
 #[allow(dead_code)]
-#[derive(Clone, Debug, Default, Deserialize)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct Variants {

--- a/src/media/stream.rs
+++ b/src/media/stream.rs
@@ -62,6 +62,7 @@ pub(crate) struct StreamVersion {
 /// A video stream.
 #[allow(dead_code)]
 #[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[request(executor(subtitles))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
@@ -89,6 +90,7 @@ pub struct Stream {
     pub variants: HashMap<Locale, Variants>,
 
     /// Might be null, for music videos and concerts mostly.
+    #[serde(skip_serializing)]
     versions: Option<Vec<StreamVersion>>,
     /// When requesting versions from [`Stream::versions`] this url is required as multiple paths
     /// exists which can lead to the [`Stream`] struct.
@@ -179,6 +181,7 @@ impl Stream {
 
 /// Subtitle for streams.
 #[derive(Clone, Debug, Default, Deserialize, Request)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct Subtitle {
@@ -201,6 +204,7 @@ impl Subtitle {
 
 /// A [`Stream`] variant.
 #[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct Variant {
@@ -215,6 +219,7 @@ pub struct Variant {
 /// Stream variants for a [`Stream`].
 #[allow(dead_code)]
 #[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct Variants {

--- a/src/media/streaming.rs
+++ b/src/media/streaming.rs
@@ -1,6 +1,7 @@
 use crate::error::CrunchyrollError;
 use crate::media::Stream;
 use crate::{Executor, Locale, Request, Result};
+use serde::{Deserialize, Serialize};
 use std::borrow::BorrowMut;
 use std::fmt::Formatter;
 use std::io::Write;
@@ -149,8 +150,7 @@ impl Stream {
 }
 
 /// Video resolution.
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "serialize", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct Resolution {
     pub width: u64,
     pub height: u64,
@@ -190,11 +190,10 @@ enum VariantDataUrl {
 
 /// Streaming data for a variant.
 #[allow(dead_code)]
-#[derive(Clone, Debug, Request)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Serialize, Clone, Debug, Request)]
 #[request(executor(segments))]
 pub struct VariantData {
-    #[cfg_attr(feature = "serialize", serde(skip))]
+    #[serde(skip)]
     executor: Arc<Executor>,
 
     pub resolution: Resolution,
@@ -202,7 +201,7 @@ pub struct VariantData {
     pub fps: f64,
     pub codecs: String,
 
-    #[cfg_attr(feature = "serialize", serde(skip))]
+    #[serde(skip)]
     url: VariantDataUrl,
 }
 

--- a/src/media/streaming.rs
+++ b/src/media/streaming.rs
@@ -150,6 +150,7 @@ impl Stream {
 
 /// Video resolution.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize, serde::Serialize))]
 pub struct Resolution {
     pub width: u64,
     pub height: u64,
@@ -190,8 +191,10 @@ enum VariantDataUrl {
 /// Streaming data for a variant.
 #[allow(dead_code)]
 #[derive(Clone, Debug, Request)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[request(executor(segments))]
 pub struct VariantData {
+    #[cfg_attr(feature = "serialize", serde(skip))]
     executor: Arc<Executor>,
 
     pub resolution: Resolution,
@@ -199,6 +202,7 @@ pub struct VariantData {
     pub fps: f64,
     pub codecs: String,
 
+    #[cfg_attr(feature = "serialize", serde(skip))]
     url: VariantDataUrl,
 }
 

--- a/src/rating/comment.rs
+++ b/src/rating/comment.rs
@@ -3,13 +3,12 @@ use crate::{enum_values, options, EmptyJsonProxy, Executor, Locale, Request, Res
 use chrono::{DateTime, Utc};
 use futures_util::FutureExt;
 use serde::de::Error;
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::json;
 use std::sync::Arc;
 
 /// Avatar of a [`CommentUser`].
-#[derive(Clone, Debug, Default, Deserialize)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct CommentUserAttributesAvatar {
@@ -18,8 +17,7 @@ pub struct CommentUserAttributesAvatar {
 }
 
 /// Attributes of a [`CommentUser`].
-#[derive(Clone, Debug, Default, Deserialize)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct CommentUserAttributes {
@@ -28,8 +26,7 @@ pub struct CommentUserAttributes {
 }
 
 /// Information about a user which wrote a [`Comment`].
-#[derive(Clone, Debug, Default, Deserialize)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct CommentUser {
@@ -40,8 +37,7 @@ pub struct CommentUser {
 }
 
 /// Number of votes users gave a [`Comment`].
-#[derive(Clone, Debug, Default, Deserialize)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct CommentVotes {
@@ -63,8 +59,7 @@ enum_values! {
 }
 
 /// Comment about a episode or movie.
-#[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Deserialize, Serialize, smart_default::SmartDefault, Request)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct Comment {

--- a/src/rating/comment.rs
+++ b/src/rating/comment.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 /// Avatar of a [`CommentUser`].
 #[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct CommentUserAttributesAvatar {
@@ -18,6 +19,7 @@ pub struct CommentUserAttributesAvatar {
 
 /// Attributes of a [`CommentUser`].
 #[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct CommentUserAttributes {
@@ -27,6 +29,7 @@ pub struct CommentUserAttributes {
 
 /// Information about a user which wrote a [`Comment`].
 #[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct CommentUser {
@@ -38,6 +41,7 @@ pub struct CommentUser {
 
 /// Number of votes users gave a [`Comment`].
 #[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct CommentVotes {
@@ -60,6 +64,7 @@ enum_values! {
 
 /// Comment about a episode or movie.
 #[derive(Clone, Debug, Deserialize, smart_default::SmartDefault, Request)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct Comment {

--- a/src/rating/review.rs
+++ b/src/rating/review.rs
@@ -22,6 +22,9 @@ enum_values! {
 
 /// Details about a star rating of [`Rating`].
 #[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
+#[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct RatingStarDetails {
     /// The amount of user ratings.
     pub displayed: String,
@@ -37,6 +40,7 @@ pub struct RatingStarDetails {
 
 /// Overview about rating statistics for a series or movie listing.
 #[derive(Clone, Debug, Default, Deserialize, Request)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct Rating {
@@ -61,6 +65,7 @@ pub struct Rating {
 
 /// Ratings for a review a user has made about a series or movie listing.
 #[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct ReviewRatings {
@@ -75,6 +80,7 @@ pub struct ReviewRatings {
 
 /// Content of a review a user has made about a series or movie listing.
 #[derive(Clone, Debug, Deserialize, smart_default::SmartDefault)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct ReviewContent {
@@ -96,6 +102,7 @@ pub struct ReviewContent {
 
 /// Author of a review.
 #[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct ReviewAuthor {
@@ -108,6 +115,7 @@ pub struct ReviewAuthor {
 
 /// A review a user has made about a series or movie listing.
 #[derive(Clone, Debug, Default, Deserialize, Request)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct Review {
@@ -164,6 +172,7 @@ impl Review {
 
 /// Review which were made by your account.
 #[derive(Clone, Debug, Default, Deserialize, Request)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct SelfReview {

--- a/src/rating/review.rs
+++ b/src/rating/review.rs
@@ -4,7 +4,7 @@ use crate::{MovieListing, Result, Series};
 use chrono::{DateTime, Utc};
 use futures_util::FutureExt;
 use serde::de::Error;
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::json;
 use std::sync::Arc;
 
@@ -21,8 +21,7 @@ enum_values! {
 }
 
 /// Details about a star rating of [`Rating`].
-#[derive(Clone, Debug, Default, Deserialize)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct RatingStarDetails {
@@ -39,8 +38,7 @@ pub struct RatingStarDetails {
 }
 
 /// Overview about rating statistics for a series or movie listing.
-#[derive(Clone, Debug, Default, Deserialize, Request)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Request)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct Rating {
@@ -64,8 +62,7 @@ pub struct Rating {
 }
 
 /// Ratings for a review a user has made about a series or movie listing.
-#[derive(Clone, Debug, Default, Deserialize)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct ReviewRatings {
@@ -79,8 +76,7 @@ pub struct ReviewRatings {
 }
 
 /// Content of a review a user has made about a series or movie listing.
-#[derive(Clone, Debug, Deserialize, smart_default::SmartDefault)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Deserialize, Serialize, smart_default::SmartDefault)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct ReviewContent {
@@ -101,8 +97,7 @@ pub struct ReviewContent {
 }
 
 /// Author of a review.
-#[derive(Clone, Debug, Default, Deserialize)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct ReviewAuthor {
@@ -114,8 +109,7 @@ pub struct ReviewAuthor {
 }
 
 /// A review a user has made about a series or movie listing.
-#[derive(Clone, Debug, Default, Deserialize, Request)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Request)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct Review {
@@ -171,8 +165,7 @@ impl Review {
 }
 
 /// Review which were made by your account.
-#[derive(Clone, Debug, Default, Deserialize, Request)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Request)]
 #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct SelfReview {

--- a/src/search.rs
+++ b/src/search.rs
@@ -6,11 +6,10 @@ mod browse {
     use crate::media::MediaType;
     use crate::{enum_values, options, Crunchyroll, Locale, MediaCollection, Request, Result};
     use futures_util::FutureExt;
-    use serde::Deserialize;
+    use serde::{Deserialize, Serialize};
 
     /// Human readable implementation of [`SimulcastSeason`].
-    #[derive(Clone, Debug, Default, Deserialize)]
-    #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+    #[derive(Clone, Debug, Default, Deserialize, Serialize)]
     #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
     #[cfg_attr(not(feature = "__test_strict"), serde(default))]
     pub struct SimulcastSeasonLocalization {
@@ -19,8 +18,7 @@ mod browse {
     }
 
     /// A simulcast season.
-    #[derive(Clone, Debug, Default, Deserialize, Request)]
-    #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+    #[derive(Clone, Debug, Default, Deserialize, Serialize, Request)]
     #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
     #[cfg_attr(not(feature = "__test_strict"), serde(default))]
     pub struct SimulcastSeason {

--- a/src/search.rs
+++ b/src/search.rs
@@ -10,6 +10,7 @@ mod browse {
 
     /// Human readable implementation of [`SimulcastSeason`].
     #[derive(Clone, Debug, Default, Deserialize)]
+    #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
     #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
     #[cfg_attr(not(feature = "__test_strict"), serde(default))]
     pub struct SimulcastSeasonLocalization {
@@ -19,6 +20,7 @@ mod browse {
 
     /// A simulcast season.
     #[derive(Clone, Debug, Default, Deserialize, Request)]
+    #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
     #[cfg_attr(feature = "__test_strict", serde(deny_unknown_fields))]
     #[cfg_attr(not(feature = "__test_strict"), serde(default))]
     pub struct SimulcastSeason {


### PR DESCRIPTION
This PR adds `#[derive(Serialize)]` which enables the serialization of most structs via [`serde`](https://serde.rs).