### PR TITLE
Allow floats in SkipEvents

### DIFF
--- a/src/media/anime/impl.rs
+++ b/src/media/anime/impl.rs
@@ -39,9 +39,9 @@ struct VideoIntroResult {
 #[cfg_attr(not(feature = "__test_strict"), serde(default))]
 pub struct SkipEventsEvent {
     /// Start of the event in seconds.
-    pub start: u32,
+    pub start: f32,
     /// End of the event in seconds.
-    pub end: u32,
+    pub end: f32,
 
     #[cfg(feature = "__test_strict")]
     approver_id: crate::StrictValue,


### PR DESCRIPTION
Some things on Crunchyroll have floats for the start/end. An example is https://static.crunchyroll.com/skip-events/production/GEVUZP7K5.json (jujutsu kaisen S01E15)