### PR TITLE
Expose access_token

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crunchyroll-rs"
-version = "0.8.6"
+version = "0.8.7"
 authors = ["Crunchy Labs Maintainers"]
 edition = "2021"
 description = "Pure Rust implementation of the crunchyroll api."

--- a/src/crunchyroll.rs
+++ b/src/crunchyroll.rs
@@ -136,6 +136,11 @@ impl Crunchyroll {
         self.executor.client.clone()
     }
 
+    pub async fn get_access_token(&self) -> (String, String) {
+        let config = self.executor.config.read().await;
+        (config.token_type.clone(), config.access_token.clone())
+    }
+
     /// Check if the current used account has premium.
     pub async fn premium(&self) -> bool {
         self.executor.premium().await


### PR DESCRIPTION
Hey guys!

I've never used rust before, but due to recent crunchyroll API changes, I've started getting into it, sorry if this is not "standard" rust practices, since this is literally the first time I've touched this thing 😆 

The intent here is to use the access_token crunchy-rs uses internally but on custom requests (for example on some URLs that are not mapped already), this removes the need to do two login requests (and so probably reduces cloudflare block probability)

Feel free to point me to another direction if needed!